### PR TITLE
feat(parser): implement @type blocks and method binding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,94 @@
 
 NLS (Natural Language Source) is a compiler that translates `.nl` specification files written in plain English into executable Python code.
 
+## Workflow: GitHub as Persistent Memory
+
+**This project uses GitHub as its persistent memory bank across all coding sessions.**
+
+### First Actions for Any Session
+
+```bash
+# 1. Check current issues and state
+gh issue list --state open
+
+# 2. Check current branch and status
+git status && git branch
+
+# 3. Find what to work on
+gh issue list --label "in-progress"
+
+# 4. If no in-progress, pick from backlog
+gh issue list --label "ready"
+```
+
+### State Management
+
+| State | Where It Lives |
+|-------|----------------|
+| **Tasks/Todos** | GitHub Issues with labels |
+| **Ideas/Research** | GitHub Issues labeled `research` or `idea` |
+| **Progress Tracking** | Issue comments + PR descriptions |
+| **Architecture Decisions** | GitHub Wiki or issue discussions |
+| **Session Handoff** | Close/update issues, push commits |
+
+### Issue Labels
+
+- `enhancement` — New features
+- `bug` — Defects
+- `research` — Investigation needed
+- `idea` — Not yet scoped
+- `in-progress` — Currently being worked on
+- `ready` — Scoped and ready to implement
+- `blocked` — Waiting on something
+
+### TDD Discipline
+
+**Always TDD. No exceptions.**
+
+```bash
+# 1. Create failing test (RED)
+# 2. Run tests - confirm failure
+pytest tests/test_X.py -v
+
+# 3. Implement minimum to pass (GREEN)
+# 4. Run tests - confirm pass
+pytest tests/test_X.py -v
+
+# 5. Refactor if needed
+# 6. Commit with issue reference
+git add . && git commit -m "feat(component): description
+
+Refs #123"
+
+# 7. Push and update issue
+git push && gh issue comment 123 --body "Implemented in commit $(git rev-parse --short HEAD)"
+```
+
+### Session End Protocol
+
+```bash
+# 1. Commit all work
+git add . && git commit -m "wip: session checkpoint"
+
+# 2. Push to remote
+git push
+
+# 3. Update any in-progress issues with status
+gh issue comment <number> --body "Session end: [summary of progress]"
+
+# 4. If blocked, add blocked label
+gh issue edit <number> --add-label "blocked" --body "Blocked on: [reason]"
+```
+
+---
+
 ## Commands
 
 ```bash
 # Install in development mode
 pip install -e .[dev]
 
-# Run tests
+# Run tests (use Python 3.12 on this system)
 pytest tests/ -v
 
 # Compile .nl file
@@ -29,11 +110,14 @@ nlsc init <path>
 - `nlsc/resolver.py` — Validates dependencies
 - `nlsc/emitter.py` — Generates Python (mock mode)
 - `nlsc/lockfile.py` — Determinism via hashing
+- `nlsc/schema.py` — Data structures (ANLU, TypeDefinition, etc.)
 
-## Current Limitations
+## Current Work
 
-The mock emitter only handles simple expression returns (`a + b`). Complex LOGIC steps generate TODO stubs. LLM integration planned.
+Check GitHub Issues: https://github.com/Mnehmos/mnehmos.nls.lang/issues
 
-## Key Principle
+## Key Principles
 
-_"The .nl file is the source. The .py file is the artifact."_
+1. _"The .nl file is the source. The .py file is the artifact."_
+2. _"GitHub is the memory. The agent is the hands."_
+3. _"TDD or it didn't happen."_

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,235 @@
+"""Tests for @type block parsing and method binding - Issue #1"""
+
+import pytest
+from nlsc.parser import parse_nl_file
+from nlsc.schema import TypeDefinition, TypeField
+
+
+class TestTypeBlockParsing:
+    """Tests for @type { ... } block parsing"""
+
+    def test_parse_simple_type(self):
+        """Parse a basic @type block with fields"""
+        source = """\
+@module test
+@target python
+
+@type Point {
+  x: number
+  y: number
+}
+"""
+        result = parse_nl_file(source)
+        assert len(result.module.types) == 1
+        point_type = result.module.types[0]
+        assert point_type.name == "Point"
+        assert len(point_type.fields) == 2
+
+    def test_parse_type_field_names(self):
+        """Verify field names are correctly parsed"""
+        source = """\
+@module test
+@target python
+
+@type Account {
+  balance: number
+  owner: string
+}
+"""
+        result = parse_nl_file(source)
+        account = result.module.types[0]
+        field_names = [f.name for f in account.fields]
+        assert "balance" in field_names
+        assert "owner" in field_names
+
+    def test_parse_type_field_types(self):
+        """Verify field types are correctly parsed"""
+        source = """\
+@module test
+@target python
+
+@type Account {
+  balance: number
+  owner: string
+  active: boolean
+}
+"""
+        result = parse_nl_file(source)
+        account = result.module.types[0]
+        balance = next(f for f in account.fields if f.name == "balance")
+        owner = next(f for f in account.fields if f.name == "owner")
+        active = next(f for f in account.fields if f.name == "active")
+
+        assert balance.type == "number"
+        assert owner.type == "string"
+        assert active.type == "boolean"
+
+    def test_parse_type_field_constraints(self):
+        """Parse field constraints like non-negative"""
+        source = """\
+@module test
+@target python
+
+@type Account {
+  balance: number, non-negative
+  name: string, required
+}
+"""
+        result = parse_nl_file(source)
+        account = result.module.types[0]
+        balance = next(f for f in account.fields if f.name == "balance")
+        name = next(f for f in account.fields if f.name == "name")
+
+        assert "non-negative" in balance.constraints
+        assert "required" in name.constraints
+
+    def test_parse_multiple_types(self):
+        """Parse multiple @type blocks in one file"""
+        source = """\
+@module test
+@target python
+
+@type Point {
+  x: number
+  y: number
+}
+
+@type Rectangle {
+  origin: Point
+  width: number
+  height: number
+}
+"""
+        result = parse_nl_file(source)
+        assert len(result.module.types) == 2
+        type_names = [t.name for t in result.module.types]
+        assert "Point" in type_names
+        assert "Rectangle" in type_names
+
+
+class TestMethodBinding:
+    """Tests for [Type.method] syntax"""
+
+    def test_parse_method_identifier(self):
+        """Parse [Type.method] as method bound to Type"""
+        source = """\
+@module test
+@target python
+
+@type Account {
+  balance: number
+}
+
+[Account.deposit]
+PURPOSE: Add funds to account
+INPUTS:
+  • self: Account
+  • amount: number
+RETURNS: Account
+"""
+        result = parse_nl_file(source)
+        assert len(result.anlus) == 1
+        method = result.anlus[0]
+        assert method.identifier == "Account.deposit"
+        assert method.bound_type == "Account"
+        assert method.method_name == "deposit"
+
+    def test_method_has_self_param(self):
+        """Method's first param should be self: TypeName"""
+        source = """\
+@module test
+@target python
+
+@type Account {
+  balance: number
+}
+
+[Account.withdraw]
+PURPOSE: Remove funds from account
+INPUTS:
+  • self: Account
+  • amount: number
+RETURNS: Account
+"""
+        result = parse_nl_file(source)
+        method = result.anlus[0]
+        assert len(method.inputs) >= 1
+        assert method.inputs[0].name == "self"
+        assert method.inputs[0].type == "Account"
+
+    def test_regular_anlu_not_method(self):
+        """Regular ANLUs without dot should not be methods"""
+        source = """\
+@module test
+@target python
+
+[add]
+PURPOSE: Add two numbers
+INPUTS:
+  • a: number
+  • b: number
+RETURNS: a + b
+"""
+        result = parse_nl_file(source)
+        anlu = result.anlus[0]
+        assert anlu.identifier == "add"
+        assert anlu.bound_type is None
+        assert anlu.method_name is None
+
+
+class TestTypeFieldDataclass:
+    """Tests for TypeField dataclass"""
+
+    def test_type_field_to_python_type(self):
+        """TypeField should convert to Python type hints"""
+        from nlsc.schema import TypeField
+
+        field = TypeField(name="balance", type="number")
+        assert field.to_python_type() == "float"
+
+        field = TypeField(name="name", type="string")
+        assert field.to_python_type() == "str"
+
+        field = TypeField(name="active", type="boolean")
+        assert field.to_python_type() == "bool"
+
+    def test_type_field_list_type(self):
+        """TypeField should handle list of X types"""
+        from nlsc.schema import TypeField
+
+        field = TypeField(name="items", type="list of string")
+        assert field.to_python_type() == "list[str]"
+
+    def test_type_field_custom_type(self):
+        """TypeField should preserve custom type names"""
+        from nlsc.schema import TypeField
+
+        field = TypeField(name="origin", type="Point")
+        assert field.to_python_type() == "Point"
+
+
+class TestTypeDependencyOrder:
+    """Tests for type-aware dependency ordering"""
+
+    def test_type_before_method(self):
+        """Types should be emitted before their methods"""
+        source = """\
+@module test
+@target python
+
+[Account.deposit]
+PURPOSE: Add funds
+INPUTS:
+  • self: Account
+  • amount: number
+RETURNS: Account
+
+@type Account {
+  balance: number
+}
+"""
+        result = parse_nl_file(source)
+        # Even though method appears first in source, type should come first in order
+        order = result.dependency_order()
+        # Types should be processed first
+        assert result.module.types[0].name == "Account"


### PR DESCRIPTION
## Summary
- Adds `@type TypeName { ... }` block syntax for defining custom types
- Adds `[Type.method]` syntax for binding methods to types
- Implements `TypeField` dataclass with type conversion support

## Changes
- **schema.py**: Added `TypeField` class, updated `TypeDefinition` to use field list, added `bound_type`/`method_name` properties to `ANLU`
- **parser.py**: Added `@type` directive handling, field parsing (bullet and indented), updated ANLU header pattern for PascalCase.method
- **test_types.py**: 12 comprehensive tests for type parsing and method binding

## Test plan
- [x] All 33 tests passing
- [x] Type block parsing works with bullet points and indented fields
- [x] Method binding correctly identifies `Type.method` identifiers
- [x] TypeField converts NLS types to Python type hints

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)