### PR TITLE
feat(diff): implement nlsc diff command

### DIFF
--- a/nlsc/diff.py
+++ b/nlsc/diff.py
@@ -1,0 +1,196 @@
+"""
+NLS Diff - Show changes since last compile
+
+Compares current .nl file state against lockfile to detect:
+- New ANLUs
+- Modified ANLUs
+- Removed ANLUs
+- Unchanged ANLUs
+"""
+
+import difflib
+from dataclasses import dataclass
+from typing import Literal
+
+from .schema import NLFile
+from .lockfile import Lockfile, hash_anlu
+
+
+@dataclass
+class ANLUChange:
+    """Represents a change to a single ANLU"""
+    identifier: str
+    status: Literal["unchanged", "modified", "new", "removed"]
+    details: str = ""
+
+
+def get_anlu_changes(nl_file: NLFile, lockfile: Lockfile) -> list[ANLUChange]:
+    """
+    Compare current NL file against lockfile to detect changes.
+
+    Args:
+        nl_file: Current parsed NL file
+        lockfile: Previous lockfile from last compile
+
+    Returns:
+        List of ANLUChange objects describing each ANLU's status
+    """
+    changes = []
+
+    # Get current ANLU identifiers and their hashes
+    current_anlus = {anlu.identifier: anlu for anlu in nl_file.anlus}
+
+    # Get previous ANLU hashes from lockfile
+    previous_hashes = {}
+    if lockfile:
+        # Check for anlus attribute (added by read_lockfile)
+        if hasattr(lockfile, "anlus") and lockfile.anlus:
+            for anlu_id, anlu_data in lockfile.anlus.items():
+                if isinstance(anlu_data, dict):
+                    previous_hashes[anlu_id] = anlu_data.get("source_hash", "")
+        # Also check modules structure
+        elif lockfile.modules:
+            for mod_name, mod_lock in lockfile.modules.items():
+                for anlu_id, anlu_lock in mod_lock.anlus.items():
+                    previous_hashes[anlu_id] = anlu_lock.source_hash
+
+    # Check each current ANLU
+    for anlu_id, anlu in current_anlus.items():
+        # Compute current hash using same function as lockfile
+        current_hash = hash_anlu(anlu)
+
+        if anlu_id not in previous_hashes:
+            # New ANLU
+            changes.append(ANLUChange(
+                identifier=anlu_id,
+                status="new",
+                details="New ANLU added"
+            ))
+        elif previous_hashes[anlu_id] != current_hash:
+            # Modified ANLU
+            changes.append(ANLUChange(
+                identifier=anlu_id,
+                status="modified",
+                details="Content changed"
+            ))
+        else:
+            # Unchanged
+            changes.append(ANLUChange(
+                identifier=anlu_id,
+                status="unchanged",
+                details=""
+            ))
+
+    # Check for removed ANLUs
+    for anlu_id in previous_hashes:
+        if anlu_id not in current_anlus:
+            changes.append(ANLUChange(
+                identifier=anlu_id,
+                status="removed",
+                details="ANLU removed"
+            ))
+
+    return changes
+
+
+def format_changes_output(changes: list[ANLUChange]) -> str:
+    """
+    Format changes for console output with colors.
+
+    Args:
+        changes: List of ANLUChange objects
+
+    Returns:
+        Formatted string for console output
+    """
+    if not changes:
+        return "No ANLUs found."
+
+    lines = []
+
+    for change in sorted(changes, key=lambda c: c.identifier):
+        if change.status == "unchanged":
+            status_str = "  "  # No marker for unchanged
+            line = f"[{change.identifier}] - unchanged"
+        elif change.status == "modified":
+            status_str = "M "
+            line = f"[{change.identifier}] - modified"
+        elif change.status == "new":
+            status_str = "+ "
+            line = f"[{change.identifier}] - new"
+        elif change.status == "removed":
+            status_str = "- "
+            line = f"[{change.identifier}] - removed"
+        else:
+            status_str = "? "
+            line = f"[{change.identifier}] - {change.status}"
+
+        lines.append(line)
+
+    return "\n".join(lines)
+
+
+def format_stat_output(changes: list[ANLUChange]) -> str:
+    """
+    Format summary statistics for --stat output.
+
+    Args:
+        changes: List of ANLUChange objects
+
+    Returns:
+        Summary string with counts
+    """
+    counts = {
+        "unchanged": 0,
+        "modified": 0,
+        "new": 0,
+        "removed": 0,
+    }
+
+    for change in changes:
+        counts[change.status] = counts.get(change.status, 0) + 1
+
+    parts = []
+    if counts["new"]:
+        parts.append(f"{counts['new']} new")
+    if counts["modified"]:
+        parts.append(f"{counts['modified']} modified")
+    if counts["removed"]:
+        parts.append(f"{counts['removed']} removed")
+    if counts["unchanged"]:
+        parts.append(f"{counts['unchanged']} unchanged")
+
+    if not parts:
+        return "No changes"
+
+    return ", ".join(parts)
+
+
+def generate_full_diff(original_code: str, new_code: str, filename: str = "output.py") -> str:
+    """
+    Generate unified diff between original and new Python code.
+
+    Args:
+        original_code: Previous Python code
+        new_code: New Python code
+        filename: Filename for diff header
+
+    Returns:
+        Unified diff string
+    """
+    original_lines = original_code.splitlines(keepends=True)
+    new_lines = new_code.splitlines(keepends=True)
+
+    diff = difflib.unified_diff(
+        original_lines,
+        new_lines,
+        fromfile=f"a/{filename}",
+        tofile=f"b/{filename}",
+    )
+
+    result = "".join(diff)
+
+    if not result:
+        return "No changes in generated Python code."
+
+    return result

--- a/tests/test_cli_diff.py
+++ b/tests/test_cli_diff.py
@@ -1,0 +1,274 @@
+"""Tests for nlsc diff command - Issue #15"""
+
+import pytest
+from pathlib import Path
+from argparse import Namespace
+
+from nlsc.cli import cmd_diff
+
+
+class TestDiffCommand:
+    """Tests for nlsc diff CLI command"""
+
+    def test_cmd_diff_exists(self):
+        """cmd_diff function should exist"""
+        assert callable(cmd_diff)
+
+    def test_diff_file_not_found(self):
+        """nlsc diff should error on missing file"""
+        args = Namespace(file="nonexistent.nl", stat=False, full=False)
+        result = cmd_diff(args)
+        assert result == 1
+
+    def test_diff_no_lockfile(self, tmp_path):
+        """nlsc diff should handle missing lockfile"""
+        nl_file = tmp_path / "test.nl"
+        nl_file.write_text("""\
+@module test
+@target python
+
+[add]
+PURPOSE: Add two numbers
+INPUTS:
+  - a: number
+  - b: number
+RETURNS: a + b
+""")
+        args = Namespace(file=str(nl_file), stat=False, full=False)
+        result = cmd_diff(args)
+        # Should succeed but show everything as new
+        assert result == 0
+
+
+class TestDiffDetection:
+    """Tests for detecting changes between .nl and lockfile"""
+
+    def test_detect_unchanged_anlu(self, tmp_path):
+        """Unchanged ANLU should be reported correctly"""
+        from nlsc.diff import get_anlu_changes
+        from nlsc.parser import parse_nl_file
+        from nlsc.lockfile import generate_lockfile
+        from nlsc.emitter import emit_python
+
+        nl_source = """\
+@module test
+@target python
+
+[add]
+PURPOSE: Add two numbers
+INPUTS:
+  - a: number
+  - b: number
+RETURNS: a + b
+"""
+        nl_file = parse_nl_file(nl_source)
+        py_code = emit_python(nl_file)
+        lockfile = generate_lockfile(nl_file, py_code, "test.py", "mock")
+
+        # Compare same source - should be unchanged
+        changes = get_anlu_changes(nl_file, lockfile)
+        assert len(changes) == 1
+        assert changes[0].status == "unchanged"
+
+    def test_detect_modified_anlu(self, tmp_path):
+        """Modified ANLU should be detected"""
+        from nlsc.diff import get_anlu_changes
+        from nlsc.parser import parse_nl_file
+        from nlsc.lockfile import generate_lockfile
+        from nlsc.emitter import emit_python
+
+        original_nl = """\
+@module test
+@target python
+
+[add]
+PURPOSE: Add two numbers
+INPUTS:
+  - a: number
+  - b: number
+RETURNS: a + b
+"""
+        modified_nl = """\
+@module test
+@target python
+
+[add]
+PURPOSE: Add two numbers together
+INPUTS:
+  - a: number
+  - b: number
+RETURNS: a + b
+"""
+        # Generate lockfile from original
+        nl_file_orig = parse_nl_file(original_nl)
+        py_code = emit_python(nl_file_orig)
+        lockfile = generate_lockfile(nl_file_orig, py_code, "test.py", "mock")
+
+        # Compare with modified
+        nl_file_mod = parse_nl_file(modified_nl)
+        changes = get_anlu_changes(nl_file_mod, lockfile)
+
+        assert len(changes) == 1
+        assert changes[0].status == "modified"
+
+    def test_detect_new_anlu(self, tmp_path):
+        """New ANLU should be detected"""
+        from nlsc.diff import get_anlu_changes
+        from nlsc.parser import parse_nl_file
+        from nlsc.lockfile import generate_lockfile
+        from nlsc.emitter import emit_python
+
+        original_nl = """\
+@module test
+@target python
+
+[add]
+PURPOSE: Add two numbers
+INPUTS:
+  - a: number
+  - b: number
+RETURNS: a + b
+"""
+        extended_nl = """\
+@module test
+@target python
+
+[add]
+PURPOSE: Add two numbers
+INPUTS:
+  - a: number
+  - b: number
+RETURNS: a + b
+
+[subtract]
+PURPOSE: Subtract b from a
+INPUTS:
+  - a: number
+  - b: number
+RETURNS: a - b
+"""
+        # Generate lockfile from original
+        nl_file_orig = parse_nl_file(original_nl)
+        py_code = emit_python(nl_file_orig)
+        lockfile = generate_lockfile(nl_file_orig, py_code, "test.py", "mock")
+
+        # Compare with extended
+        nl_file_ext = parse_nl_file(extended_nl)
+        changes = get_anlu_changes(nl_file_ext, lockfile)
+
+        assert len(changes) == 2
+        statuses = {c.identifier: c.status for c in changes}
+        assert statuses["add"] == "unchanged"
+        assert statuses["subtract"] == "new"
+
+    def test_detect_removed_anlu(self, tmp_path):
+        """Removed ANLU should be detected"""
+        from nlsc.diff import get_anlu_changes
+        from nlsc.parser import parse_nl_file
+        from nlsc.lockfile import generate_lockfile
+        from nlsc.emitter import emit_python
+
+        original_nl = """\
+@module test
+@target python
+
+[add]
+PURPOSE: Add two numbers
+INPUTS:
+  - a: number
+  - b: number
+RETURNS: a + b
+
+[subtract]
+PURPOSE: Subtract b from a
+INPUTS:
+  - a: number
+  - b: number
+RETURNS: a - b
+"""
+        reduced_nl = """\
+@module test
+@target python
+
+[add]
+PURPOSE: Add two numbers
+INPUTS:
+  - a: number
+  - b: number
+RETURNS: a + b
+"""
+        # Generate lockfile from original
+        nl_file_orig = parse_nl_file(original_nl)
+        py_code = emit_python(nl_file_orig)
+        lockfile = generate_lockfile(nl_file_orig, py_code, "test.py", "mock")
+
+        # Compare with reduced
+        nl_file_red = parse_nl_file(reduced_nl)
+        changes = get_anlu_changes(nl_file_red, lockfile)
+
+        assert len(changes) == 2
+        statuses = {c.identifier: c.status for c in changes}
+        assert statuses["add"] == "unchanged"
+        assert statuses["subtract"] == "removed"
+
+
+class TestDiffOutput:
+    """Tests for diff output formatting"""
+
+    def test_stat_output(self, tmp_path):
+        """--stat should show summary"""
+        from nlsc.diff import format_stat_output
+
+        changes = [
+            type("Change", (), {"identifier": "add", "status": "unchanged"})(),
+            type("Change", (), {"identifier": "sub", "status": "modified"})(),
+            type("Change", (), {"identifier": "mul", "status": "new"})(),
+        ]
+
+        output = format_stat_output(changes)
+        assert "1 unchanged" in output
+        assert "1 modified" in output
+        assert "1 new" in output
+
+
+class TestFullDiff:
+    """Tests for unified diff output"""
+
+    def test_full_diff_shows_python_changes(self, tmp_path):
+        """--full should show unified diff of Python output"""
+        from nlsc.diff import generate_full_diff
+        from nlsc.parser import parse_nl_file
+        from nlsc.emitter import emit_python
+
+        original_nl = """\
+@module test
+@target python
+
+[add]
+PURPOSE: Add two numbers
+INPUTS:
+  - a: number
+  - b: number
+RETURNS: a + b
+"""
+        modified_nl = """\
+@module test
+@target python
+
+[add]
+PURPOSE: Add two values
+INPUTS:
+  - a: number
+  - b: number
+RETURNS: a + b
+"""
+        nl_file_orig = parse_nl_file(original_nl)
+        py_orig = emit_python(nl_file_orig)
+
+        nl_file_mod = parse_nl_file(modified_nl)
+        py_mod = emit_python(nl_file_mod)
+
+        diff_output = generate_full_diff(py_orig, py_mod)
+
+        # Should contain diff markers
+        assert "---" in diff_output or "unchanged" in diff_output.lower()


### PR DESCRIPTION
## Summary
- Implements #15: nlsc diff - show changes since last compile
- Adds `nlsc/diff.py` module for change detection
- Supports `--stat` for summary and `--full` for unified diff

## Changes
- **nlsc/diff.py**: New module with:
  - `get_anlu_changes()` - detect new/modified/removed/unchanged ANLUs
  - `format_changes_output()` - format for console
  - `format_stat_output()` - summary counts
  - `generate_full_diff()` - unified diff of Python output
- **nlsc/lockfile.py**: Implemented proper `read_lockfile()` parser
- **nlsc/cli.py**: Added `diff` subcommand with `--stat` and `--full` flags
- **tests/test_cli_diff.py**: 9 comprehensive tests

## Usage
```bash
# Show ANLU change status
nlsc diff src/math.nl
[add] - unchanged
[multiply] - modified
[divide] - new

# Summary only
nlsc diff src/math.nl --stat
1 modified, 1 new, 1 unchanged

# Full Python diff
nlsc diff src/math.nl --full
--- a/math.py
+++ b/math.py
...
```

## Test Plan
- [x] All 139 tests pass
- [x] Detects unchanged/modified/new/removed ANLUs
- [x] --stat shows summary counts
- [x] --full shows unified diff

Closes #15

---
Generated with [Claude Code](https://claude.com/claude-code)