### PR TITLE
docs: Add MkDocs site with comprehensive documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material pymdown-extensions
+
+      - name: Build and deploy
+        run: mkdocs gh-deploy --force

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,279 @@
+# Architecture
+
+This document describes the internal architecture of the NLS compiler.
+
+## Pipeline Overview
+
+```mermaid
+flowchart LR
+    A[".nl file"] --> B[Parser]
+    B --> C[AST]
+    C --> D[Resolver]
+    D --> E[Emitter]
+    E --> F[".py file"]
+    E --> G[".nl.lock"]
+```
+
+The compiler follows a classic pipeline architecture:
+
+1. **Parser** — Converts `.nl` text to AST
+2. **Resolver** — Validates dependencies and ordering
+3. **Emitter** — Generates Python code
+4. **Lockfile** — Records hashes for reproducibility
+
+---
+
+## Module Breakdown
+
+### Core Modules
+
+| Module                 | Purpose                      | Lines |
+| ---------------------- | ---------------------------- | ----- |
+| `parser.py`            | Regex-based parser           | ~500  |
+| `parser_treesitter.py` | Tree-sitter parser           | ~600  |
+| `resolver.py`          | Dependency resolution        | ~100  |
+| `emitter.py`           | Python code generation       | ~400  |
+| `lockfile.py`          | Hash computation and storage | ~200  |
+| `schema.py`            | AST data structures          | ~300  |
+
+### CLI Modules
+
+| Module       | Purpose                             |
+| ------------ | ----------------------------------- |
+| `cli.py`     | Command-line interface              |
+| `graph.py`   | Visualization (Mermaid, DOT, ASCII) |
+| `diff.py`    | Change detection                    |
+| `watch.py`   | File watcher                        |
+| `atomize.py` | Python → NL extraction              |
+
+---
+
+## Parser Backends
+
+### Regex Parser (Default)
+
+The regex parser uses pattern matching to tokenize and parse `.nl` files.
+
+```python
+# Pattern examples from parser.py
+ANLU_START = r"^\[([a-z][a-z0-9.-]*)\]\s*$"
+DIRECTIVE = r"^@(module|version|target|imports)"
+SECTION = r"^(PURPOSE|INPUTS|GUARDS|LOGIC|RETURNS|DEPENDS|EDGE CASES):"
+```
+
+**Pros:**
+
+- Zero dependencies
+- Fast for simple files
+- Easy to understand
+
+**Cons:**
+
+- Limited error recovery
+- Complex patterns for edge cases
+
+### Tree-sitter Parser
+
+The tree-sitter parser uses a formal grammar for parsing.
+
+```bash
+# Install tree-sitter support
+pip install nlsc[treesitter]
+
+# Use tree-sitter parser
+nlsc --parser treesitter compile src/auth.nl
+```
+
+**Pros:**
+
+- Better error recovery
+- Incremental parsing
+- Foundation for LSP/IDE support
+
+**Cons:**
+
+- Requires native dependency
+- Slightly more complex setup
+
+---
+
+## AST Schema
+
+The AST is defined in `schema.py`:
+
+```python
+@dataclass
+class NLFile:
+    module: ModuleDirective
+    version: str | None
+    target: str
+    imports: list[str]
+    anlus: list[ANLU]
+    types: list[TypeDef]
+    tests: list[TestSpec]
+    literals: list[LiteralBlock]
+
+@dataclass
+class ANLU:
+    identifier: str
+    purpose: str
+    inputs: list[InputDef]
+    guards: list[Guard]
+    logic: list[LogicStep]
+    returns: str
+    depends: list[str]
+    edge_cases: list[EdgeCase]
+```
+
+---
+
+## Resolution
+
+The resolver validates:
+
+1. **Dependency existence** — All `DEPENDS` references exist
+2. **Cycle detection** — No circular dependencies
+3. **Ordering** — Topological sort for code generation
+
+```python
+result = resolve_dependencies(nl_file)
+if not result.success:
+    for error in result.errors:
+        print(f"{error.anlu_id}: {error.message}")
+```
+
+---
+
+## Code Emission
+
+The emitter transforms AST to Python:
+
+### ANLU → Function
+
+```nl
+[add]
+PURPOSE: Add two numbers
+INPUTS:
+  - a: number
+  - b: number
+RETURNS: a + b
+```
+
+Becomes:
+
+```python
+def add(a: float, b: float) -> float:
+    """Add two numbers."""
+    return a + b
+```
+
+### @type → Dataclass
+
+```nl
+@type Point {
+  x: number
+  y: number
+}
+```
+
+Becomes:
+
+```python
+@dataclass
+class Point:
+    """Point type."""
+    x: float
+    y: float
+```
+
+### GUARDS → Validation
+
+```nl
+GUARDS:
+  - divisor must not be zero -> ValueError("Cannot divide by zero")
+```
+
+Becomes:
+
+```python
+if divisor == 0:
+    raise ValueError("Cannot divide by zero")
+```
+
+---
+
+## Lockfile
+
+Lockfiles ensure reproducible builds:
+
+```yaml
+# example.nl.lock
+version: "1.0"
+source_hash: "a1b2c3..."
+target_hash: "d4e5f6..."
+anlus:
+  add:
+    hash: "abc123..."
+    inputs: ["a: number", "b: number"]
+    returns: "a + b"
+  multiply:
+    hash: "def456..."
+    inputs: ["a: number", "b: number"]
+    returns: "a × b"
+llm_backend: "mock"
+compiled_at: "2024-01-15T10:30:00Z"
+```
+
+The lockfile enables:
+
+- **Change detection** (`nlsc diff`)
+- **Reproducible builds**
+- **Audit trails**
+
+---
+
+## Extension Points
+
+### Adding a New Target
+
+1. Create `emitter_<target>.py`
+2. Implement `emit_<target>(nl_file: NLFile) -> str`
+3. Register in `cli.py` compile command
+
+### Adding a New Parser Feature
+
+1. Update grammar in `tree-sitter-nl/grammar.js`
+2. Regenerate with `npx tree-sitter generate`
+3. Update `parser_treesitter.py` to handle new nodes
+4. Update `parser.py` with matching regex patterns
+
+### Adding a New CLI Command
+
+1. Create `cmd_<name>` function in `cli.py`
+2. Add subparser in `main()`
+3. Add case in command dispatch
+
+---
+
+## Testing
+
+```bash
+# Run all tests
+pytest tests/ -v
+
+# Run specific test module
+pytest tests/test_emitter.py -v
+
+# Run tree-sitter grammar tests
+cd tree-sitter-nl && npx tree-sitter test
+```
+
+Test coverage includes:
+
+- **12** regex parser tests
+- **25** tree-sitter grammar tests
+- **9** parser parity tests
+- **15+** emitter tests
+- Dataflow, guards, types, roundtrip tests
+
+**Total: 160 tests passing**

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,294 @@
+# CLI Reference
+
+The `nlsc` command-line interface provides 8 commands for working with NLS files.
+
+## Global Options
+
+```bash
+nlsc [--parser {regex,treesitter}] [--version] [--help] <command>
+```
+
+| Option      | Description                                       |
+| ----------- | ------------------------------------------------- |
+| `--parser`  | Parser backend: `regex` (default) or `treesitter` |
+| `--version` | Show version number                               |
+| `--help`    | Show help message                                 |
+
+---
+
+## Commands
+
+### `nlsc init`
+
+Initialize a new NLS project with standard folder structure.
+
+```bash
+nlsc init [path]
+```
+
+| Argument | Description                                    |
+| -------- | ---------------------------------------------- |
+| `path`   | Project directory (default: current directory) |
+
+**Example:**
+
+```bash
+nlsc init my-project
+```
+
+Creates:
+
+```
+my-project/
+├── nl.config.yaml    # Project configuration
+├── src/              # Source .nl files
+│   └── __init__.py
+└── tests/            # Generated tests
+    └── __init__.py
+```
+
+---
+
+### `nlsc compile`
+
+Compile a `.nl` file to the target language (currently Python).
+
+```bash
+nlsc compile <file> [-t TARGET] [-o OUTPUT]
+```
+
+| Option         | Description                         |
+| -------------- | ----------------------------------- |
+| `file`         | Path to `.nl` file                  |
+| `-t, --target` | Target language (default: `python`) |
+| `-o, --output` | Output file path                    |
+
+**Examples:**
+
+```bash
+# Basic compile
+nlsc compile src/auth.nl
+
+# Compile with tree-sitter parser
+nlsc --parser treesitter compile src/auth.nl
+
+# Specify output file
+nlsc compile src/auth.nl -o lib/auth.py
+```
+
+**Generated files:**
+
+- `<name>.py` — Python module
+- `test_<name>.py` — Test file (if `@test` blocks present)
+- `<name>.nl.lock` — Lockfile for reproducibility
+
+---
+
+### `nlsc verify`
+
+Validate a `.nl` file without generating code. Checks syntax and dependencies.
+
+```bash
+nlsc verify <file>
+```
+
+**Example:**
+
+```bash
+nlsc verify src/order.nl
+```
+
+Output:
+
+```
+Verifying src/order.nl (parser: regex)...
+  ✓ Syntax valid: 5 ANLUs
+  ✓ Dependencies valid
+  ✓ All ANLUs valid
+
+Verification passed!
+```
+
+---
+
+### `nlsc test`
+
+Run `@test` specifications from a `.nl` file.
+
+```bash
+nlsc test <file> [-v]
+```
+
+| Option          | Description        |
+| --------------- | ------------------ |
+| `file`          | Path to `.nl` file |
+| `-v, --verbose` | Verbose output     |
+
+**Example:**
+
+```bash
+nlsc test src/math.nl -v
+```
+
+The command:
+
+1. Compiles the `.nl` file to a temp directory
+2. Generates test code from `@test` blocks
+3. Runs pytest on the generated tests
+
+---
+
+### `nlsc graph`
+
+Generate dependency and dataflow visualizations.
+
+```bash
+nlsc graph <file> [-f FORMAT] [-a ANLU] [--dataflow] [-o OUTPUT]
+```
+
+| Option         | Description                                        |
+| -------------- | -------------------------------------------------- |
+| `file`         | Path to `.nl` file                                 |
+| `-f, --format` | Output format: `mermaid` (default), `dot`, `ascii` |
+| `-a, --anlu`   | Specific ANLU for dataflow visualization           |
+| `--dataflow`   | Show dataflow instead of FSM states                |
+| `-o, --output` | Output file path (default: stdout)                 |
+
+**Examples:**
+
+```bash
+# Module dependency graph
+nlsc graph src/order.nl --format mermaid
+
+# Dataflow for specific ANLU
+nlsc graph src/order.nl --anlu process-order --dataflow
+
+# Export as DOT for Graphviz
+nlsc graph src/order.nl --format dot -o deps.dot
+```
+
+---
+
+### `nlsc diff`
+
+Show changes since last compile by comparing against the lockfile.
+
+```bash
+nlsc diff <file> [--stat] [--full]
+```
+
+| Option   | Description            |
+| -------- | ---------------------- |
+| `file`   | Path to `.nl` file     |
+| `--stat` | Show summary only      |
+| `--full` | Show full unified diff |
+
+**Examples:**
+
+```bash
+# Show changed ANLUs
+nlsc diff src/api.nl
+
+# Summary statistics
+nlsc diff src/api.nl --stat
+
+# Full unified diff
+nlsc diff src/api.nl --full
+```
+
+---
+
+### `nlsc watch`
+
+Watch a directory for `.nl` file changes and automatically recompile.
+
+```bash
+nlsc watch [dir] [-q] [-t] [-d DEBOUNCE]
+```
+
+| Option           | Description                            |
+| ---------------- | -------------------------------------- |
+| `dir`            | Directory to watch (default: current)  |
+| `-q, --quiet`    | Suppress success messages              |
+| `-t, --test`     | Run tests after successful compile     |
+| `-d, --debounce` | Debounce interval in ms (default: 100) |
+
+**Examples:**
+
+```bash
+# Watch current directory
+nlsc watch
+
+# Watch with tests
+nlsc watch src/ --test
+
+# Quiet mode with custom debounce
+nlsc watch src/ -q -d 500
+```
+
+Press `Ctrl+C` to stop watching.
+
+---
+
+### `nlsc atomize`
+
+Extract ANLUs from existing Python source code (reverse compilation).
+
+```bash
+nlsc atomize <file> [-o OUTPUT] [-m MODULE]
+```
+
+| Option         | Description                     |
+| -------------- | ------------------------------- |
+| `file`         | Path to Python file             |
+| `-o, --output` | Output `.nl` file path          |
+| `-m, --module` | Module name for generated `.nl` |
+
+**Example:**
+
+```bash
+nlsc atomize legacy/utils.py -o src/utils.nl -m utils
+```
+
+This extracts functions from Python and generates corresponding ANLU blocks.
+
+---
+
+## Exit Codes
+
+| Code | Meaning                                       |
+| ---- | --------------------------------------------- |
+| 0    | Success                                       |
+| 1    | Error (parse error, validation failure, etc.) |
+
+## Environment Variables
+
+| Variable      | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `NLSC_PARSER` | Default parser backend (`regex` or `treesitter`) |
+
+## Configuration
+
+Project settings are stored in `nl.config.yaml`:
+
+```yaml
+project:
+  name: my-project
+  version: 0.1.0
+
+compiler:
+  default_target: python
+  llm_backend: mock
+  cache_strategy: aggressive
+
+targets:
+  python:
+    version: ">=3.11"
+    style: black
+    type_hints: strict
+
+validation:
+  require_purpose: true
+  require_guards: false
+  max_anlu_complexity: 10
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,157 @@
+# Getting Started
+
+This guide will walk you through installing NLS and creating your first compiled specification.
+
+## Installation
+
+=== "Basic Install"
+
+    ```bash
+    pip install -e .
+    ```
+
+=== "With Tree-sitter Parser"
+
+    ```bash
+    pip install -e ".[treesitter]"
+    ```
+
+    The tree-sitter parser provides faster parsing and better error recovery.
+
+=== "Development Setup"
+
+    ```bash
+    git clone https://github.com/Mnehmos/mnehmos.nls.lang.git
+    cd mnehmos.nls.lang
+    pip install -e ".[dev,treesitter]"
+    ```
+
+## Initialize a Project
+
+Create a new NLS project with the proper folder structure:
+
+```bash
+nlsc init my-project
+cd my-project
+```
+
+This creates:
+
+```
+my-project/
+├── nl.config.yaml    # Project configuration
+├── src/              # Source .nl files
+│   └── __init__.py
+└── tests/            # Generated tests
+    └── __init__.py
+```
+
+## Your First .nl File
+
+Create `src/calculator.nl`:
+
+```nl
+@module calculator
+@target python
+
+[add]
+PURPOSE: Add two numbers together
+INPUTS:
+  - a: number
+  - b: number
+RETURNS: a + b
+
+[divide]
+PURPOSE: Divide two numbers safely
+INPUTS:
+  - numerator: number
+  - divisor: number
+GUARDS:
+  - divisor must not be zero -> ValueError("Cannot divide by zero")
+RETURNS: numerator / divisor
+
+@test [add] {
+  add(2, 3) == 5
+  add(-1, 1) == 0
+}
+```
+
+## Compile to Python
+
+```bash
+nlsc compile src/calculator.nl
+```
+
+Output:
+
+```
+Compiling src/calculator.nl (parser: regex)...
+  ✓ Parsed 2 ANLUs
+  ✓ Resolved dependencies
+  ✓ Generated calculator.py (25 lines)
+  ✓ Generated test_calculator.py
+  ✓ Updated calculator.nl.lock
+
+Compilation complete!
+```
+
+## Run the Tests
+
+```bash
+nlsc test src/calculator.nl
+```
+
+Output:
+
+```
+Running 2 test cases from src/calculator.nl...
+  • [add]: 2 cases
+
+✓ All 2 tests passed!
+```
+
+## Use the Generated Code
+
+```python
+from src.calculator import add, divide
+
+result = add(2, 3)  # 5
+ratio = divide(10, 2)  # 5.0
+
+try:
+    divide(1, 0)
+except ValueError as e:
+    print(e)  # "Cannot divide by zero"
+```
+
+## Next Steps
+
+- **[CLI Reference](cli-reference.md)** — Learn all 8 nlsc commands
+- **[Language Specification](language-spec.md)** — Full syntax reference
+- **[Architecture](architecture.md)** — How the compiler works
+
+## Workflow Tips
+
+### Watch Mode
+
+Automatically recompile on file changes:
+
+```bash
+nlsc watch src/ --test
+```
+
+### Visualize Dependencies
+
+Generate Mermaid diagrams:
+
+```bash
+nlsc graph src/calculator.nl --format mermaid
+```
+
+### See What Changed
+
+View differences since last compile:
+
+```bash
+nlsc diff src/calculator.nl
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,78 @@
+# NLS Compiler
+
+> **The source code is English. The compiled artifact is Python.**
+
+NLS is a programming language where specifications are written in plain English that anyone can read—managers, auditors, domain experts—not just programmers. The `nlsc` compiler translates `.nl` files into executable Python with full type hints, validation, and documentation.
+
+## Why NLS?
+
+- **Readable by everyone** — Non-programmers can review business logic
+- **Auditable** — Clear mapping from intent to implementation
+- **Testable** — Specifications include test cases
+- **Versionable** — Lock files ensure reproducibility
+- **Toolable** — Tree-sitter grammar enables IDE support
+
+## Quick Example
+
+```nl
+@module calculator
+@target python
+
+[divide]
+PURPOSE: Divide two numbers safely
+INPUTS:
+  - numerator: number
+  - divisor: number
+GUARDS:
+  - divisor must not be zero -> ValueError("Cannot divide by zero")
+RETURNS: numerator / divisor
+```
+
+Compiles to:
+
+```python
+def divide(numerator: float, divisor: float) -> float:
+    """Divide two numbers safely."""
+    if divisor == 0:
+        raise ValueError("Cannot divide by zero")
+    return numerator / divisor
+```
+
+## Project Status
+
+| Component            | Status      |
+| -------------------- | ----------- |
+| Parser (regex)       | ✅ Complete |
+| Parser (tree-sitter) | ✅ Complete |
+| Python emitter       | ✅ Complete |
+| Type generation      | ✅ Complete |
+| Guard validation     | ✅ Complete |
+| Dataflow analysis    | ✅ Complete |
+| Test runner          | ✅ Complete |
+| Watch mode           | ✅ Complete |
+| VS Code extension    | 🔜 Planned  |
+| TypeScript target    | 🔜 Planned  |
+
+**160 tests passing** — Production-ready for Python target.
+
+## Get Started
+
+<div class="grid cards" markdown>
+
+- :material-download: **[Installation](getting-started.md#installation)**
+
+  Install nlsc with pip
+
+- :material-console: **[CLI Reference](cli-reference.md)**
+
+  All 8 commands documented
+
+- :material-book-open: **[Language Spec](language-spec.md)**
+
+  Full syntax reference
+
+- :material-cog: **[Architecture](architecture.md)**
+
+  How the compiler works
+
+</div>

--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -1,0 +1,332 @@
+# Language Specification
+
+This document defines the complete syntax of `.nl` files.
+
+## File Structure
+
+An `.nl` file consists of:
+
+1. **Directives** — Module metadata (`@module`, `@version`, `@target`, `@imports`)
+2. **ANLU Blocks** — Function specifications (`[name]`)
+3. **Type Definitions** — Custom types (`@type`)
+4. **Test Blocks** — Test specifications (`@test`)
+5. **Literal Blocks** — Code escape hatches (`@literal`)
+6. **Comments** — Lines starting with `#`
+
+## Directives
+
+### `@module`
+
+**Required.** Declares the module name.
+
+```nl
+@module calculator
+```
+
+Pattern: `^[a-z][a-z0-9_]*$` (lowercase snake_case)
+
+### `@version`
+
+Optional semantic version.
+
+```nl
+@version 1.0.0
+```
+
+### `@target`
+
+**Required.** Specifies the compilation target.
+
+```nl
+@target python
+```
+
+Supported: `python` (more coming)
+
+### `@imports`
+
+Optional comma-separated import list.
+
+```nl
+@imports jwt, datetime, typing
+```
+
+---
+
+## ANLU Blocks
+
+ANLU (Atomic Natural Language Unit) blocks define functions.
+
+```nl
+[function-name]
+PURPOSE: Single sentence describing what this does
+INPUTS:
+  - param1: type
+  - param2: type, optional
+GUARDS:
+  - condition -> ErrorType("message")
+LOGIC:
+  1. Description of step -> variable
+  2. Another step
+EDGE CASES:
+  - condition -> behavior
+RETURNS: expression
+DEPENDS: [other-function], [another]
+```
+
+### Identifier
+
+ANLU names use **kebab-case**:
+
+```nl
+[calculate-tax]
+[is-empty]
+[validate-user-token]
+```
+
+Pattern: `^[a-z][a-z0-9-]*$`
+
+For methods, use dot notation:
+
+```nl
+[User.validate]
+[Order.calculate-total]
+```
+
+### PURPOSE
+
+**Required.** Single sentence in imperative mood.
+
+```nl
+PURPOSE: Calculate the total price including tax
+```
+
+### INPUTS
+
+Typed parameter list with optional constraints.
+
+```nl
+INPUTS:
+  - amount: number
+  - rate: number, "Tax rate as decimal"
+  - currency: string, optional
+```
+
+Bullets can be `•`, `-`, or `*`.
+
+### GUARDS
+
+Preconditions with error mappings.
+
+```nl
+GUARDS:
+  - amount must be non-negative -> ValueError("Amount cannot be negative")
+  - rate must be between 0 and 1 -> ValidationError(INVALID_RATE, "Rate must be 0-1")
+```
+
+### LOGIC
+
+Numbered steps describing the algorithm.
+
+```nl
+LOGIC:
+  1. Calculate base tax -> tax
+  2. Add service fee if applicable -> fee
+  3. Combine tax and fee -> total
+```
+
+Steps can include:
+
+- **Output binding**: `-> variable`
+- **Conditionals**: `IF condition THEN action`
+- **State markers**: `[state] action`
+
+### EDGE CASES
+
+Explicit boundary condition handling.
+
+```nl
+EDGE CASES:
+  - Zero amount -> return 0
+  - Empty list -> return None
+```
+
+### RETURNS
+
+**Required.** Output expression or type.
+
+```nl
+RETURNS: base + tax
+RETURNS: TaxResult with amount, effective_rate
+RETURNS: list of Order
+```
+
+### DEPENDS
+
+Dependencies on other ANLUs.
+
+```nl
+DEPENDS: [validate-input], [calculate-base]
+```
+
+---
+
+## Type System
+
+### Primitives
+
+| Type      | Description                 |
+| --------- | --------------------------- |
+| `number`  | Integer or float            |
+| `string`  | Text                        |
+| `boolean` | `true` / `false`            |
+| `void`    | No return value             |
+| `any`     | Dynamic typing escape hatch |
+
+### Composites
+
+**List:**
+
+```nl
+list of number
+list of User
+```
+
+**Optional:**
+
+```nl
+string?
+User?
+```
+
+**Map:**
+
+```nl
+map of string to number
+```
+
+**Union:**
+
+```nl
+string | number
+Success | Error
+```
+
+---
+
+## Type Definitions
+
+Define custom types with `@type`:
+
+```nl
+@type Point {
+  x: number
+  y: number
+}
+
+@type Order {
+  id: string, required
+  items: list of OrderItem
+  total: number, "Order total in cents"
+  status: string
+}
+```
+
+### Inheritance
+
+```nl
+@type OrderItem extends BaseItem {
+  quantity: number
+  price: number
+}
+```
+
+### Field Constraints
+
+```nl
+@type User {
+  email: string, required
+  age: number, optional
+  role: string, "User role in system"
+}
+```
+
+---
+
+## Test Blocks
+
+Define test cases with `@test`:
+
+```nl
+@test [add] {
+  add(1, 2) == 3
+  add(0, 0) == 0
+  add(-5, 5) == 0
+}
+
+@test [divide] {
+  divide(10, 2) == 5.0
+  divide(9, 3) == 3.0
+}
+```
+
+Test blocks generate executable pytest code.
+
+---
+
+## Literal Blocks
+
+Escape hatch for exact code when needed:
+
+```nl
+[slugify]
+PURPOSE: Convert text to URL-friendly slug format
+INPUTS:
+  - text: string
+
+@literal python {
+import re
+
+def slugify(text: str) -> str:
+    """Convert text to URL-friendly slug format."""
+    text = text.lower().strip()
+    text = re.sub(r'\s+', '-', text)
+    text = re.sub(r'[^a-z0-9-]', '', text)
+    return text.strip('-')
+}
+```
+
+Literal blocks bypass the compiler and emit code exactly as written.
+
+---
+
+## Comments
+
+Lines starting with `#` are comments:
+
+```nl
+# Math Module
+# This provides basic arithmetic operations
+
+@module math
+@target python
+
+# Addition function
+[add]
+PURPOSE: Add two numbers
+...
+```
+
+---
+
+## Formatting Notes
+
+1. **Bullets** are flexible: `•`, `-`, or `*`
+2. **Arrows** are flexible: `→` (Unicode) or `->` (ASCII)
+3. **Section headers** are case-insensitive
+4. **Indentation** uses spaces for visual structure
+5. **Unicode** is supported in text content
+
+## Grammar Reference
+
+For the complete formal grammar, see [nl-grammar.ebnf](nl-grammar.ebnf).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,57 @@
+site_name: NLS Compiler
+site_description: Natural Language Source - Write specs in English, compile to Python
+site_url: https://mnehmos.github.io/mnehmos.nls.lang/
+repo_url: https://github.com/Mnehmos/mnehmos.nls.lang
+repo_name: mnehmos.nls.lang
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - content.code.copy
+    - content.code.annotate
+    - search.highlight
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - pymdownx.details
+  - attr_list
+  - md_in_html
+  - tables
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - CLI Reference: cli-reference.md
+  - Language Specification: language-spec.md
+  - Architecture: architecture.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/Mnehmos/mnehmos.nls.lang


### PR DESCRIPTION
## Summary
Adds complete documentation site using MkDocs Material theme with automatic GitHub Pages deployment.

## Changes
- **mkdocs.yml** - MkDocs configuration with Material theme, dark/light mode, code copy
- **.github/workflows/docs.yml** - Auto-deploy on push to main/master
- **docs/index.md** - Documentation homepage
- **docs/getting-started.md** - Installation and first project guide
- **docs/cli-reference.md** - All 8 CLI commands documented
- **docs/language-spec.md** - Complete NL syntax reference
- **docs/architecture.md** - Pipeline diagram and module breakdown

## After Merge
Enable GitHub Pages in repo settings: Settings → Pages → Source: gh-pages branch

Closes #28