### PR TITLE
fix(emitter): improve return type inference and void handling

### DIFF
--- a/nlsc/emitter.py
+++ b/nlsc/emitter.py
@@ -328,6 +328,14 @@ def emit_body_mock(anlu: ANLU) -> str:
 
     returns = anlu.returns.strip()
 
+    # Handle void return - no return statement or just pass
+    if returns.lower() == "void" or returns.lower() == "none":
+        if anlu.guards:
+            lines = emit_guards(anlu)
+            lines.append("    return None")
+            return "\n".join(lines)
+        return "    return None"
+
     # Direct expression returns (a + b, a × b, etc.)
     # Replace math symbols
     expr = returns.replace("×", "*").replace("÷", "/")

--- a/nlsc/schema.py
+++ b/nlsc/schema.py
@@ -238,6 +238,17 @@ class ANLU:
                         # Check if it looks like a boolean expression
                         if any(op in expr for op in [">", "<", "==", "!=", ">=", "<=", " and ", " or ", " not "]):
                             return "bool"
+                        # Check if it's a constructor call (Type(...))
+                        import re
+                        ctor_match = re.match(r'([A-Z][a-zA-Z0-9_]*)\s*\(', expr)
+                        if ctor_match:
+                            return ctor_match.group(1)
+                        # Check if it's an empty list []
+                        if expr.strip() == "[]":
+                            return "list"
+                        # Check if it's an empty dict {}
+                        if expr.strip() == "{}":
+                            return "dict"
                     break
 
         # Check if RETURNS variable matches an input name - use input's type
@@ -245,9 +256,13 @@ class ANLU:
             if returns == inp.name:
                 return inp.to_python_type()
 
-        # Default fallback for unknown variable names - assume float for simple identifiers
+        # Default fallback for unknown identifiers
         if returns.isidentifier():
-            return "float"
+            # If it starts with uppercase, treat as custom type
+            if returns[0].isupper():
+                return returns
+            # Otherwise it's probably a variable - use Any
+            return "Any"
 
         return type_map.get(returns, returns)
     


### PR DESCRIPTION
## Summary
- Add void/none handling - generates `return None` instead of `return void`
- Detect constructor calls in LOGIC to infer return type (e.g., `Lockfile()`)
- Detect empty list `[]` and dict `{}` initializers for type inference
- Use `Any` instead of `float` for unknown lowercase identifiers
- Treat uppercase identifiers as custom types

## Before/After
| Function | Before | After |
|----------|--------|-------|
| `write_lockfile` | `return void` | `return None` |
| `generate_lockfile` | `-> float` | `-> Lockfile` |
| `read_lockfile` | `-> float` | `-> Lockfile` |
| `verify_lockfile` | `-> float` | `-> list` |

## Test plan
- [x] 159 tests passing
- [x] Atomize → compile round-trip produces valid Python

Fixes #46, #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)