### PR TITLE
Configure mypy type checking

### DIFF
--- a/nlsc/atomize.py
+++ b/nlsc/atomize.py
@@ -59,7 +59,7 @@ def python_type_to_nl(type_node: ast.expr | None) -> str:
     return ast.unparse(type_node) if hasattr(ast, "unparse") else "any"
 
 
-def extract_guards(func: ast.FunctionDef) -> list[dict[str, str]]:
+def extract_guards(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[dict[str, str]]:
     """
     Extract GUARDS from if/raise patterns at the start of function body.
 
@@ -137,7 +137,7 @@ def extract_guards(func: ast.FunctionDef) -> list[dict[str, str]]:
     return guards
 
 
-def extract_logic_steps(func: ast.FunctionDef) -> list[str]:
+def extract_logic_steps(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
     """
     Extract LOGIC steps from function body.
 
@@ -210,7 +210,7 @@ def extract_logic_steps(func: ast.FunctionDef) -> list[str]:
         # Capture for loops
         if isinstance(node, ast.For):
             try:
-                target = ast.unparse(node.target)
+                target = ast.unparse(node.target)  # type: ignore[assignment]
                 iter_expr = ast.unparse(node.iter)
                 # Extract the body as a simple statement if possible
                 body_stmts = _extract_for_body(node.body)
@@ -259,7 +259,7 @@ def _extract_for_body(body: list) -> list[str]:
     return stmts
 
 
-def extract_return_expression(func: ast.FunctionDef) -> str:
+def extract_return_expression(func: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
     """
     Extract the return expression from a function.
 
@@ -344,7 +344,7 @@ def extract_return_expression(func: ast.FunctionDef) -> str:
                         break
 
     # Fallback: find any return statement
-    for node in ast.walk(func):
+    for node in ast.walk(func):  # type: ignore[assignment]
         if isinstance(node, ast.Return) and node.value:
             try:
                 expr = ast.unparse(node.value)

--- a/nlsc/cli.py
+++ b/nlsc/cli.py
@@ -267,8 +267,8 @@ def cmd_verify(args: argparse.Namespace) -> int:
 
     if errors:
         print(f"  {_cross()} Validation errors:")
-        for err in errors:
-            print(f"    - {err}")
+        for validation_err in errors:
+            print(f"    - {validation_err}")
         return 1
 
     print(f"  {_check()} All ANLUs valid")

--- a/nlsc/diff.py
+++ b/nlsc/diff.py
@@ -12,6 +12,8 @@ import difflib
 from dataclasses import dataclass
 from typing import Literal
 
+from typing import Optional
+
 from .schema import NLFile
 from .lockfile import Lockfile, hash_anlu
 
@@ -24,7 +26,7 @@ class ANLUChange:
     details: str = ""
 
 
-def get_anlu_changes(nl_file: NLFile, lockfile: Lockfile) -> list[ANLUChange]:
+def get_anlu_changes(nl_file: NLFile, lockfile: Optional[Lockfile]) -> list[ANLUChange]:
     """
     Compare current NL file against lockfile to detect changes.
 

--- a/nlsc/emitter.py
+++ b/nlsc/emitter.py
@@ -9,7 +9,7 @@ import math
 import re
 from typing import Optional
 
-from .schema import ANLU, NLFile, TypeDefinition, Invariant
+from .schema import ANLU, NLFile, TypeDefinition, Invariant, LogicStep
 
 
 def _is_safe_numeric(value: str) -> bool:
@@ -307,13 +307,13 @@ def _convert_type_return(returns_expr: str, anlu) -> str:
     return returns_expr
 
 
-def _extract_action(step) -> Optional[str]:
+def _extract_action(step: LogicStep) -> Optional[str]:
     """
     Extract executable Python action from a logic step.
 
     Returns the action string, or None if it's purely descriptive.
     """
-    desc = step.description.strip()
+    desc: str = step.description.strip()
 
     # Remove state name prefix if present
     if desc.startswith("["):

--- a/nlsc/roundtrip.py
+++ b/nlsc/roundtrip.py
@@ -48,7 +48,7 @@ def validate_roundtrip(
         py_code = emit_python(nl_file)
 
         # Execute original
-        ns1 = {}
+        ns1: dict[str, Any] = {}
         exec(py_code, ns1)
 
         if function_name not in ns1:
@@ -64,7 +64,7 @@ def validate_roundtrip(
         py_code2 = emit_python(nl_file2)
 
         # Execute regenerated
-        ns2 = {}
+        ns2: dict[str, Any] = {}
         exec(py_code2, ns2)
 
         if function_name not in ns2:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "hypothesis>=6.0",
+    "mypy>=1.0",
 ]
 llm = [
     "anthropic>=0.18.0",
@@ -62,3 +63,17 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short"
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_ignores = true
+ignore_missing_imports = true
+# Start with relaxed settings, tighten over time
+check_untyped_defs = false
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = "nlsc.parser_treesitter"
+# Tree-sitter bindings have dynamic typing
+ignore_errors = true


### PR DESCRIPTION
## Summary
- Add mypy configuration to pyproject.toml with relaxed initial settings
- Add mypy>=1.0 to dev dependencies
- Fix type errors across 5 files

## Type Fixes

| File | Fix |
|------|-----|
| diff.py | `Optional[Lockfile]` parameter type |
| roundtrip.py | `dict[str, Any]` for exec namespaces |
| atomize.py | Union types for AST nodes, type ignore comments |
| emitter.py | `LogicStep` type annotation |
| cli.py | Variable rename to avoid shadowing |

## mypy Configuration

```toml
[tool.mypy]
python_version = "3.11"
warn_return_any = true
warn_unused_ignores = true
ignore_missing_imports = true
check_untyped_defs = false  # Relaxed for now
disallow_untyped_defs = false  # Relaxed for now
```

Tree-sitter parser is excluded due to dynamic bindings.

## Test plan
- [x] mypy passes with no errors
- [x] All 239 tests pass

Refs #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Extended internal logic to support asynchronous operations alongside synchronous ones.
  * Improved and broadened type annotations across the codebase for clearer static checking.

* **Chores**
  * Added type-checking tooling and configuration to development dependencies for improved code quality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->