### PR TITLE
Auto-detect tree-sitter and use as default parser

### DIFF
--- a/nlsc/cli.py
+++ b/nlsc/cli.py
@@ -54,14 +54,25 @@ def _cross() -> str:
     except (UnicodeEncodeError, LookupError):
         return "[X]"
 
-# Parser selection
-_use_treesitter = False
+# Parser selection - default to tree-sitter if available
+def _detect_treesitter() -> bool:
+    """Check if tree-sitter parser is available."""
+    try:
+        from . import parser_treesitter
+        return parser_treesitter.is_available()
+    except ImportError:
+        return False
+
+
+_use_treesitter = _detect_treesitter()
 
 
 def set_parser_backend(backend: str) -> None:
-    """Set the parser backend to use: 'regex' or 'treesitter'."""
+    """Set the parser backend to use: 'regex', 'treesitter', or 'auto'."""
     global _use_treesitter
-    if backend == "treesitter":
+    if backend == "auto":
+        _use_treesitter = _detect_treesitter()
+    elif backend == "treesitter":
         # Check if tree-sitter is available
         try:
             from . import parser_treesitter
@@ -633,9 +644,9 @@ The conversation is the programming. The .nl file is the receipt.
     )
     parser.add_argument(
         "--parser",
-        choices=["regex", "treesitter"],
-        default="regex",
-        help="Parser backend: 'regex' (default) or 'treesitter'"
+        choices=["auto", "regex", "treesitter"],
+        default="auto",
+        help="Parser backend: 'auto' (default, uses tree-sitter if available), 'regex', or 'treesitter'"
     )
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")


### PR DESCRIPTION
## Summary
- Add `auto` parser mode (new default) that uses tree-sitter if available
- Change CLI default from `regex` to `auto`
- Tree-sitter now used automatically when installed via `pip install nlsc[treesitter]`
- Falls back to regex parser if tree-sitter not available

## Changes

### Before
```bash
nlsc compile file.nl        # Uses regex parser
nlsc compile file.nl --parser treesitter  # Explicit tree-sitter
```

### After
```bash
nlsc compile file.nl        # Uses tree-sitter if available, else regex
nlsc compile file.nl --parser regex       # Force regex
nlsc compile file.nl --parser treesitter  # Force tree-sitter (error if not installed)
```

## Benefits
- Better error recovery with tree-sitter
- Incremental parsing support
- More robust parsing of edge cases
- Backwards compatible - regex fallback works unchanged

## Test plan
- [x] All 239 tests pass
- [x] Auto-detection works correctly

Refs #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic parser backend detection that intelligently switches between tree-sitter and regex parsers based on availability.
  * Introduced new "auto" mode (now default) for parser selection, which uses tree-sitter when available and gracefully falls back to regex.
  * Improved error messaging when requested parser is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->