### PR TITLE
feat(parser): add hybrid parsing for tree-sitter parity

### DIFF
--- a/nlsc/parser_treesitter.py
+++ b/nlsc/parser_treesitter.py
@@ -106,9 +106,13 @@ def _parse_invariant_blocks(source: str) -> list[Invariant]:
 
 
 def _parse_main_block(source: str) -> list[str]:
-    """Parse @main block using regex fallback."""
+    """Parse @main block using regex fallback.
+
+    Tracks brace depth to handle nested braces correctly.
+    """
     main_buffer = []
     in_main = False
+    brace_depth = 0
 
     for line in source.split("\n"):
         stripped = line.strip()
@@ -116,11 +120,22 @@ def _parse_main_block(source: str) -> list[str]:
         # Start of @main block
         if stripped.startswith("@main"):
             in_main = True
+            # Check if opening brace is on same line
+            if "{" in stripped:
+                brace_depth = 1
             continue
 
         # Inside main block
         if in_main:
-            if stripped == "}":
+            # Count braces in this line
+            open_braces = stripped.count("{")
+            close_braces = stripped.count("}")
+
+            # Update depth before processing
+            brace_depth += open_braces - close_braces
+
+            # Block ends when depth reaches 0
+            if brace_depth <= 0:
                 in_main = False
             elif stripped and not stripped.startswith("#"):
                 main_buffer.append(stripped)


### PR DESCRIPTION
## Summary

Implements hybrid parsing approach for tree-sitter to achieve full feature parity with the regex parser.

### Changes
- Add regex fallback functions in `parser_treesitter.py` for constructs not in tree-sitter grammar:
  - `_parse_property_blocks()` - parses @property blocks with forall quantifiers
  - `_parse_invariant_blocks()` - parses @invariant Type { conditions }
  - `_parse_main_block()` - parses @main { statements }
- Update `parse_nl_file_treesitter()` to return complete NLFile with all fields
- Add 12 comprehensive parity tests in `test_parser_parity.py`

### Why hybrid approach?
The tree-sitter grammar doesn't include @property, @invariant, and @main blocks. Rather than extend the grammar (which would require rebuilding the parser), we use regex fallback for these specific constructs while tree-sitter handles the core ANLU/type/test parsing.

## Test plan
- [x] All 254 tests pass
- [x] New parity tests verify both parsers produce identical output
- [x] Tested with examples containing @property, @invariant, @main blocks

Closes #79, closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for parsing @property, @invariant, and @main code blocks in NL source files.
  * Enhanced parser robustness with fallback mechanisms for improved block coverage.

* **Tests**
  * Added new test methods to validate consistency between different parsing approaches.
  * Introduced comparison helpers for comprehensive block validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->