### PR TITLE
fix: reject natural-language guard text in emitter (closes #121)

### DIFF
--- a/tests/test_issue_121_guard_validation.py
+++ b/tests/test_issue_121_guard_validation.py
@@ -1,0 +1,28 @@
+"""Regression tests for Issue #121: NL guards must not emit invalid Python."""
+
+import pytest
+
+from nlsc.emitter import emit_python
+from nlsc.parser import parse_nl_file
+
+
+def test_should_require_explicit_python_guard_expression_when_guard_is_natural_language():
+    """Natural-language guard text should be rejected with a clear validation contract."""
+    source = """\
+@module guards_issue_121
+@target python
+
+[safe-divide]
+PURPOSE: divide numbers safely
+INPUTS:
+  - dividend: number
+  - divisor: number
+GUARDS:
+  • divisor must not be zero → ValueError(Division by zero)
+RETURNS: dividend / divisor
+"""
+
+    parsed = parse_nl_file(source)
+
+    with pytest.raises(Exception, match="explicit Python guard expression|invalid guard expression|natural language"):
+        emit_python(parsed)


### PR DESCRIPTION
## Summary\n- add regression coverage for natural-language guard text rejection\n- validate guard conditions as Python expressions before emission\n- raise explicit emitter error when guard text is not a valid Python expression\n\n## TDD\n- Red: [`test_should_require_explicit_python_guard_expression_when_guard_is_natural_language()`](tests/test_issue_121_guard_validation.py:9)\n- Green: minimal emitter validation fix in [`emit_guards()`](nlsc/emitter.py:265)\n- Blue: no-op refactor, targeted suite verified green\n\n## Verification\n- python -m pytest tests/test_issue_121_guard_validation.py tests/test_emit_guards.py tests/test_emitter.py tests/test_parser.py -q\n\nCloses #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guard expression validation to detect and reject invalid guards with detailed error messages.
  * Guard expressions are now validated early in the emission process, catching invalid syntax before code generation.

* **Tests**
  * Added regression test to ensure guard expressions are properly validated and invalid guards are rejected with appropriate error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->