### PR TITLE
test(parser): add property coverage for INPUTS grammar invariants (closes #77)

### DIFF
--- a/nlsc/parser.py
+++ b/nlsc/parser.py
@@ -370,6 +370,12 @@ def parse_nl_file(source: str, source_path: Optional[str] = None) -> NLFile:
 
         # Skip comments and empty lines (unless in a section)
         if PATTERNS["comment"].match(line):
+            if current_section == "inputs":
+                raise ParseError(
+                    "Invalid INPUTS bullet marker; expected one of: •, -, *",
+                    line_num,
+                    line,
+                )
             continue
         if PATTERNS["empty"].match(line) and current_section is None:
             continue
@@ -500,6 +506,9 @@ def parse_nl_file(source: str, source_path: Optional[str] = None) -> NLFile:
 
             # Parse section content
             if current_section:
+                if PATTERNS["empty"].match(line):
+                    continue
+
                 # Bullet point
                 bullet_match = PATTERNS["bullet"].match(line)
                 if bullet_match:
@@ -527,6 +536,13 @@ def parse_nl_file(source: str, source_path: Optional[str] = None) -> NLFile:
                         for var in logic_step.assigns:
                             logic_assigns[var] = step_num
                     continue
+
+                if current_section == "inputs":
+                    raise ParseError(
+                        "Invalid INPUTS bullet marker; expected one of: •, -, *",
+                        line_num,
+                        line,
+                    )
 
         # Parse type fields
         if current_type:

--- a/tests/test_hypothesis_properties.py
+++ b/tests/test_hypothesis_properties.py
@@ -329,6 +329,36 @@ RETURNS: void
         assert positions == sorted(positions)
 
 
+class TestGrammarInvariantProperties:
+    """Property-based regression tests for grammar invariants from docs/nl-grammar.ebnf."""
+
+    @given(
+        invalid_bullet=st.characters(
+            blacklist_characters="•-* \t\n\r",
+            blacklist_categories=("Cs",)
+        )
+    )
+    @settings(max_examples=50)
+    def test_should_reject_inputs_item_when_bullet_marker_is_not_in_grammar(self, invalid_bullet):
+        """Parser should reject INPUTS items whose bullet is not one of: •, -, * (EBNF bullet invariant)."""
+        source = f"""\
+@module test
+@target python
+
+[parse-bullet-invariant]
+PURPOSE: validate INPUTS bullet grammar
+INPUTS:
+  {invalid_bullet} value: number
+RETURNS: value
+"""
+
+        with pytest.raises(
+            ParseError,
+            match=r"(?i)(bullet|inputs|invalid|line)",
+        ):
+            parse_nl_file(source)
+
+
 class TestSecurityProperties:
     """Property-based tests for security validation"""
 


### PR DESCRIPTION
## Summary\n- add property-based regression for INPUTS bullet marker grammar invariant\n- enforce parser rejection for non-grammar INPUTS item markers\n- tighten parser behavior to avoid silently accepting invalid INPUTS structure\n\n## TDD\n- Red: failing property test in [`test_should_reject_inputs_item_when_bullet_marker_is_not_in_grammar()`](tests/test_hypothesis_properties.py:336)\n- Green: minimal parser enforcement in [`parse_nl_file()`](nlsc/parser.py:304)\n- Blue: no-op/refinement pass with targeted parser+property verification\n\n## Verification\n- python -m pytest -q tests/test_parser.py tests/test_hypothesis_properties.py\n\nCloses #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for INPUTS sections to enforce proper bullet formatting and reject invalid markers.
  * Parser now raises clear errors for malformed INPUTS entries.

* **Tests**
  * Added comprehensive property-based tests to verify INPUTS bullet validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->