### PR TITLE
feat(stdlib): add @use directives with bundled stdlib + overrides (closes #90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ DEPENDS: [other-function], [another]
 @version 1.0.0         # Semantic version
 @target python         # Target language
 @imports other_module  # Import dependencies
+@use math.core         # Stdlib domain dependency (Issue #90)
 ```
 
 ## The Philosophy

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -62,6 +62,7 @@ nlsc compile <file> [-t TARGET] [-o OUTPUT]
 | `file`         | Path to `.nl` file                  |
 | `-t, --target` | Target language (default: `python`) |
 | `-o, --output` | Output file path                    |
+| `--stdlib-path` | Additional stdlib root (repeatable; higher precedence than env + bundled) |
 
 **Examples:**
 
@@ -74,7 +75,24 @@ nlsc --parser treesitter compile src/auth.nl
 
 # Specify output file
 nlsc compile src/auth.nl -o lib/auth.py
+
+# Provide an additional stdlib root (repeatable)
+nlsc compile src/main.nl --stdlib-path ./vendor/stdlib
 ```
+
+#### Stdlib overrides for `@use` (Issue #90)
+
+If your `.nl` file contains `@use <domain>` directives, `nlsc compile` resolves domains by searching stdlib roots in this order:
+
+1. Project-local override: `.nls/stdlib/`
+2. CLI override roots: `--stdlib-path <dir>` (repeatable; earlier flags win)
+3. Environment override roots: `NLS_STDLIB_PATH` (path list; left-to-right)
+4. Bundled stdlib shipped with `nlsc`: `nlsc/stdlib/`
+
+Domain-to-path mapping is deterministic:
+
+* `@use math.core` → `v{major}/math/core.nl`
+* `@use v1.math.core` pins `major=1`
 
 **Generated files:**
 

--- a/docs/design/issue-90-use-directives.md
+++ b/docs/design/issue-90-use-directives.md
@@ -1,0 +1,360 @@
+# Issue #90 — `@use` Directives (Slice C) — Contract / Design
+
+Run: phase2-milestones-2026-02-08  
+Task: issue-90-arch
+
+This document defines the *end-to-end* contract for resolving `@use` directives against a bundled stdlib plus user overrides.
+
+---
+
+## 0) Goals / non-goals
+
+### Goals
+
+1. Deterministic mapping from `@use <domain>` → a single `.nl` source file.
+2. Explicit, testable override precedence (project-local first, then user/CLI, then bundled).
+3. Versionable stdlib domains without breaking existing projects.
+4. Errors are structured enough to be asserted in tests (code + message + attempted search roots).
+
+### Non-goals
+
+* Defining new language semantics of imported symbols (type checking / export syntax is out of Slice C).
+* Network resolution or package registry.
+
+---
+
+## 1) Stdlib layout proposal (bundled `.nl` files)
+
+### 1.1 Bundled stdlib root
+
+Bundled stdlib ships *inside the `nlsc` distribution* as plain `.nl` sources (not generated artifacts):
+
+* Root directory: [`nlsc/stdlib/`](nlsc/stdlib/)
+
+### 1.2 Versioned layout (major-version directories)
+
+Stdlib modules are organized by **major version** at the top level, then by **domain path**:
+
+```
+nlsc/
+  stdlib/
+    MANIFEST.json
+    v1/
+      math/
+        core.nl
+        stats.nl
+      text/
+        core.nl
+    v2/
+      ...
+```
+
+**Rules**
+
+* A **domain** is the dotted path in `@use`, e.g. `math.core`.
+* Domain maps to a relative path under a version root by replacing `.` with `/` and appending `.nl`.
+  * Example: `math.core` → `math/core.nl`
+* Version roots are named `v{MAJOR}` (e.g. `v1`, `v2`).
+* [`nlsc/stdlib/MANIFEST.json`](nlsc/stdlib/MANIFEST.json) declares the *default major* used when a directive does not specify a major.
+
+### 1.3 Recommended project-local override layout
+
+Project-local overrides are **in-repo** sources under a hidden config directory:
+
+* Root directory: [`.nls/stdlib/`](.nls/stdlib/)
+* Same layout as bundled stdlib, including major version roots.
+
+Example:
+
+```
+.nls/
+  stdlib/
+    v1/
+      math/
+        core.nl   # project override
+```
+
+Rationale:
+
+* Keeps overrides out of the normal source tree.
+* Allows pinning/parallel majors the same way as bundled stdlib.
+
+---
+
+## 2) Domain resolution algorithm
+
+### 2.1 Directive syntax (Slice C scope)
+
+This contract assumes the parser produces a normalized directive object:
+
+* `raw`: original text
+* `domain`: dotted identifier, e.g. `math.core`
+* optional `major`: integer major version (see §2.3)
+
+Concrete surface forms are intentionally limited for Slice C:
+
+* `@use math.core`
+* Optional version prefix: `@use v1.math.core`
+
+### 2.2 Resolution roots (search order)
+
+Resolution searches a list of **roots**, in priority order (first match wins):
+
+1. **Project-local override root**: [`.nls/stdlib/`](.nls/stdlib/)
+2. **User-provided roots** (highest to lowest):
+   * CLI: `--stdlib-path <dir>` (repeatable; earlier flags have higher precedence)
+   * Env: `NLS_STDLIB_PATH` (path-list; left-to-right precedence)
+3. **Bundled root**: [`nlsc/stdlib/`](nlsc/stdlib/)
+
+Notes:
+
+* Each root is treated as a *filesystem sandbox*. Resolution MUST NOT traverse outside roots.
+* Roots that do not exist are ignored **except**: if provided explicitly via CLI, non-existent paths SHOULD fail fast with a CLI error (outside `@use` resolution).
+
+### 2.3 Major-version selection
+
+Given `@use <spec>`:
+
+* If `<spec>` begins with `v{N}.` (e.g. `v1.math.core`), then `major=N` and the domain is the remainder (`math.core`).
+* Otherwise `major` is taken from the bundled manifest default (and may be overridden by a future CLI option such as `--stdlib-major`, not required for Slice C).
+
+Bundled manifest minimum fields:
+
+```json
+{
+  "schema": 1,
+  "default_major": 1,
+  "versions": {
+    "v1": { "semver": "1.2.0" },
+    "v2": { "semver": "2.0.0" }
+  }
+}
+```
+
+### 2.4 Candidate path generation
+
+For a resolved `(major, domain)` pair, generate candidates **in this exact order**:
+
+1. `v{major}/{domain_as_path}.nl`
+
+Where:
+
+* `domain_as_path = domain.replace('.', '/')`
+
+Example:
+
+* `@use math.core` with default major 1 → candidate: `v1/math/core.nl`
+
+Future-compatible extension (explicitly **out-of-scope** for Slice C but reserved):
+
+* secondary candidate: `v{major}/{domain_as_path}/index.nl`
+
+### 2.5 Conflict & error behavior (testable contract)
+
+Resolution outcome is exactly one of:
+
+* **Resolved**: a single filesystem path.
+* **Missing domain**: no root contained the candidate module.
+* **Ambiguous**: multiple roots at the *same precedence tier* contain the candidate.
+
+Define precedence tiers:
+
+* Tier 0: project-local override root
+* Tier 1: CLI `--stdlib-path` roots (each flag is its own tier level; earlier flags higher)
+* Tier 2: env roots (each entry is its own tier level; earlier entries higher)
+* Tier 3: bundled root
+
+**Ambiguity rule**
+
+* If *two different roots* at the same tier level both contain the candidate path, raise an **Ambiguous** error.
+  * Example: two `--stdlib-path` flags with the same precedence level is impossible if each flag is a level; ambiguity can still occur within env roots if you treat the entire env list as one level—this spec avoids that by defining each entry as a level.
+  * Therefore, ambiguity most commonly occurs when the implementation allows multiple values within one “level” (e.g., a single CLI flag that accepts a list). If the implementation chooses list semantics, it MUST then implement ambiguity detection within that level.
+
+**Error codes** (required for tests)
+
+* `EUSE001` Missing domain
+  * Include: `domain`, `major`, `attempted_roots[]`, `candidate_relpath`
+* `EUSE002` Ambiguous domain
+  * Include: `domain`, `major`, `candidate_relpath`, `matches[]` (absolute or normalized paths)
+
+### 2.6 Deterministic resolution flow (reference pseudocode)
+
+```python
+def resolve_use(domain_spec: str, roots: list[Root], default_major: int) -> ResolvedUse:
+    major, domain = parse_major_prefix(domain_spec, default_major)
+    rel = f"v{major}/" + domain.replace(".", "/") + ".nl"
+
+    tried: list[str] = []
+    matches: list[str] = []
+
+    for root in roots:  # already expanded into strict precedence order
+        tried.append(root.path)
+        candidate = join(root.path, rel)
+        if exists(candidate):
+            matches.append(candidate)
+            return ResolvedUse(domain=domain, major=major, path=candidate)
+
+    raise MissingDomain(code="EUSE001", domain=domain, major=major, rel=rel, tried=tried)
+```
+
+Implementation note: if an implementation permits multiple candidates per precedence step, replace the “return first match” with “collect matches within a step and error if >1”.
+
+---
+
+## 3) User override precedence (CLI/env/project-local)
+
+### 3.1 Precedence summary
+
+Highest to lowest:
+
+1. [`.nls/stdlib/`](.nls/stdlib/) (project-local override)
+2. CLI `--stdlib-path` (repeatable; left-to-right)
+3. Env `NLS_STDLIB_PATH` (left-to-right)
+4. Bundled [`nlsc/stdlib/`](nlsc/stdlib/)
+
+### 3.2 Contract for “override” vs “conflict”
+
+* If a higher-precedence root contains the module, it **overrides** all lower-precedence matches (no warning required for Slice C).
+* If two matches are present at the *same* precedence step (implementation-defined; see §2.5), it is a hard error `EUSE002`.
+
+---
+
+## 4) Versioning strategy notes (stdlib domains)
+
+### 4.1 Why version at the domain root
+
+Stdlib changes will happen; without versioning, `@use math.core` is inherently unstable across compiler releases.
+
+### 4.2 Proposed invariants
+
+* Stdlib is semver-versioned **per major root**: `v1`, `v2`, …
+* Within the same major root:
+  * backward-compatible additions are allowed (new helpers, new domains)
+  * breaking changes are not allowed
+* Breaking changes require a new `v{major+1}` root.
+
+### 4.3 Pinning & reproducibility (lockfile-facing, Slice C notes)
+
+To support reproducible builds:
+
+* The lockfile SHOULD record:
+  * which stdlib major is in use when `@use` omits explicit major
+  * the bundled stdlib semver for that major (from `MANIFEST.json`)
+  * hashes for each resolved stdlib module file (content hash)
+
+This allows:
+
+* Detecting “stdlib drift” when upgrading `nlsc`.
+* Keeping projects stable even as bundled stdlib evolves.
+
+---
+
+## 5) Test plan (Red-phase cases)
+
+All tests below are stated as *black-box* scenarios that can be implemented against the resolver + CLI, without requiring semantic analysis.
+
+### 5.1 Happy path — bundled stdlib
+
+Given:
+
+* Bundled root contains `v1/math/core.nl`.
+* Program contains `@use math.core`.
+
+Expect:
+
+* Resolution selects bundled `.../nlsc/stdlib/v1/math/core.nl`.
+* Dependency graph includes that file as an input (or equivalent representation).
+
+### 5.2 Missing domain
+
+Given:
+
+* No roots contain `v1/math/missing.nl`.
+* Program contains `@use math.missing`.
+
+Expect:
+
+* Compile fails with `EUSE001`.
+* Error includes `domain=math.missing`, `major=1`, `candidate_relpath=v1/math/missing.nl`.
+* Error includes `attempted_roots` in the exact precedence order used.
+
+### 5.3 Project-local override wins
+
+Given:
+
+* Bundled root contains `v1/math/core.nl`.
+* Project-local override root contains `.nls/stdlib/v1/math/core.nl`.
+* Program contains `@use math.core`.
+
+Expect:
+
+* Resolution selects project-local `.nls/stdlib/v1/math/core.nl`.
+* No error.
+
+### 5.4 CLI override wins over env and bundled
+
+Given:
+
+* CLI provides `--stdlib-path <X>`.
+* `<X>/v1/math/core.nl` exists.
+* Env root also has a different copy.
+* Bundled exists.
+
+Expect:
+
+* Resolution selects `<X>/v1/math/core.nl`.
+
+### 5.5 Conflict / ambiguity at same precedence step
+
+This is an *implementation choice test*: it becomes relevant if `--stdlib-path` accepts a list in one flag or if env list entries are treated as a single precedence step.
+
+Given:
+
+* Two stdlib roots considered the same precedence step both contain `v1/math/core.nl`.
+
+Expect:
+
+* Compile fails with `EUSE002`.
+* Error includes `matches[]` listing both candidates.
+
+---
+
+## 6) Acceptance criteria (exact, testable)
+
+### 6.1 Resolution correctness
+
+1. `@use math.core` resolves to **exactly one** file path or fails with a structured error.
+2. Domain-to-path mapping is deterministic: `math.core` → `math/core.nl` (with `.nl` suffix and version prefix).
+3. If project-local override exists at [`.nls/stdlib/`](.nls/stdlib/), it is selected over any CLI/env/bundled match.
+4. If CLI `--stdlib-path` is provided, it is selected over env and bundled.
+5. If no roots contain the candidate file, compilation fails with error code `EUSE001` and includes the `candidate_relpath` and `attempted_roots`.
+
+### 6.2 Version behavior
+
+6. If `@use v1.math.core` is used, resolution MUST use major=1 regardless of bundled default.
+7. If `@use math.core` omits explicit major, resolution MUST use bundled manifest `default_major` (until an explicit `--stdlib-major` is introduced).
+
+### 6.3 Security / sandboxing
+
+8. Resolver MUST NOT allow `@use` to escape roots (no `..`, no absolute paths, no path separators in domain segments).
+9. When resolution fails, error output MUST NOT reveal unrelated filesystem paths beyond the declared roots.
+
+### 6.4 Determinism & diagnostics
+
+10. For a fixed set of roots and filesystem contents, resolution results are deterministic across runs.
+11. Errors include a stable code (`EUSE001`/`EUSE002`) suitable for assertions.
+
+---
+
+## Appendix A — Mermaid overview
+
+```mermaid
+flowchart TD
+  A[@use domain] --> B[Parse optional vN. prefix]
+  B --> C[major + domain]
+  C --> D[relpath = v{major}/domain_as_path.nl]
+  D --> E{Search roots in order}
+  E -->|found| F[Resolved path]
+  E -->|not found| G[EUSE001 MissingDomain]
+```
+

--- a/docs/error-reference.md
+++ b/docs/error-reference.md
@@ -257,6 +257,45 @@ DEPENDS: [common]
 DEPENDS: [common]
 ```
 
+---
+
+## Stdlib `@use` Errors (Issue #90)
+
+Errors in this section are raised when resolving `@use <domain>` directives against stdlib roots.
+
+### `EUSE001` — Missing stdlib domain
+
+Compilation failed because a referenced stdlib **domain** could not be resolved.
+
+Typical output includes stable fields suitable for assertions:
+
+* `code=EUSE001`
+* `domain=<domain>`
+* `major=<major>`
+* `candidate_relpath=v{major}/.../.nl`
+* `attempted_roots=[...]`
+
+**Example** (`@use math.missing`):
+
+```text
+Error: EUSE001 domain=math.missing major=1 candidate_relpath=v1/math/missing.nl attempted_roots=[...]
+```
+
+**Common causes**
+
+1. The domain is misspelled.
+2. The stdlib root you expected is not in the search path.
+3. You forgot to include a project-local override in `.nls/stdlib/`.
+
+**Fix**
+
+* Ensure the module exists at the expected path (example for default major 1):
+  * `v1/math/core.nl` for `@use math.core`
+* Provide an override root:
+  * CLI: `nlsc compile src/main.nl --stdlib-path ./vendor/stdlib`
+  * Env: set `NLS_STDLIB_PATH` to a path-list of stdlib roots
+  * Project: create `.nls/stdlib/v1/...`
+
 ### Self Dependency
 
 ```

--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -51,6 +51,33 @@ Optional comma-separated import list.
 @imports jwt, datetime, typing
 ```
 
+### `@use`
+
+Declare a dependency on a **stdlib domain module**.
+
+```nl
+@use math.core
+```
+
+`@use` supports an optional major-version prefix:
+
+```nl
+@use v1.math.core
+```
+
+Resolution (Issue #90, Slice C):
+
+1. Project-local override: `.nls/stdlib/`
+2. CLI override roots: `nlsc compile ... --stdlib-path <dir>` (repeatable; earlier flags win)
+3. Environment override roots: `NLS_STDLIB_PATH` (path-list; left-to-right)
+4. Bundled stdlib: `nlsc/stdlib/`
+
+Domain-to-path mapping is deterministic:
+
+* `math.core` → `v{major}/math/core.nl`
+
+If the domain cannot be resolved, compilation fails with a stable error code (see [`docs/error-reference.md`](docs/error-reference.md)).
+
 ---
 
 ## ANLU Blocks

--- a/nlsc/__main__.py
+++ b/nlsc/__main__.py
@@ -2,7 +2,9 @@
 Entry point for running nlsc as a module: python -m nlsc
 """
 
+import sys
+
 from .cli import main
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/nlsc/parser.py
+++ b/nlsc/parser.py
@@ -27,7 +27,7 @@ class ParseError(Exception):
 # Regex patterns for parsing
 PATTERNS = {
     "anlu_header": re.compile(r"^\[([A-Za-z][A-Za-z0-9.-]*)\]\s*$"),
-    "directive": re.compile(r"^@(module|version|target|imports|types|type|test|property|invariant|literal|main)\s*(.*)$"),
+    "directive": re.compile(r"^@(module|version|target|imports|use|types|type|test|property|invariant|literal|main)\s*(.*)$"),
     "purpose": re.compile(r"^PURPOSE:\s*(.+)$", re.IGNORECASE),
     "inputs": re.compile(r"^INPUTS:\s*$", re.IGNORECASE),
     "guards": re.compile(r"^GUARDS:\s*$", re.IGNORECASE),
@@ -402,6 +402,10 @@ def parse_nl_file(source: str, source_path: Optional[str] = None) -> NLFile:
                     _validate_import_token(i, line_num)
                     for i in directive_value.split(",")
                 ]
+            elif directive_type == "use":
+                # Issue #90: record raw @use domain spec; resolver handles version/roots.
+                if directive_value:
+                    module.uses.append(directive_value)
             elif directive_type == "main":
                 # Start main block
                 in_main_block = True

--- a/nlsc/schema.py
+++ b/nlsc/schema.py
@@ -437,6 +437,8 @@ class Module:
     version: str = "0.1.0"
     target: str = "python"
     imports: list[str] = field(default_factory=list)
+    # Issue #90: stdlib domain dependencies declared via @use
+    uses: list[str] = field(default_factory=list)
     types: list[TypeDefinition] = field(default_factory=list)
 
 

--- a/nlsc/stdlib/MANIFEST.json
+++ b/nlsc/stdlib/MANIFEST.json
@@ -1,0 +1,10 @@
+{
+  "schema": 1,
+  "default_major": 1,
+  "versions": {
+    "v1": {
+      "semver": "1.0.0"
+    }
+  }
+}
+

--- a/nlsc/stdlib/v1/math/core.nl
+++ b/nlsc/stdlib/v1/math/core.nl
@@ -1,0 +1,8 @@
+@module math.core
+
+# Bundled stdlib domain for Issue #90 tests.
+
+[noop]
+PURPOSE: stdlib placeholder
+RETURNS: 1
+

--- a/nlsc/stdlib_resolver.py
+++ b/nlsc/stdlib_resolver.py
@@ -1,0 +1,160 @@
+"""Issue #90: resolve `@use <domain>` directives against a versioned stdlib.
+
+Slice C contract highlights (see docs/design/issue-90-use-directives.md):
+
+* Supports `@use math.core` and `@use v1.math.core`
+* Resolves to a single `.nl` source file inside a stdlib root
+* Root precedence (highest first):
+  1) Project-local `.nls/stdlib`
+  2) CLI `--stdlib-path` (repeatable; earlier flags higher precedence)
+  3) Env `NLS_STDLIB_PATH` (path-list; left-to-right precedence)
+  4) Bundled `nlsc/stdlib`
+
+This module intentionally keeps the error surface stable for tests:
+* `EUSE001` Missing domain (also used for invalid domain tokens in Slice C)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ENV_STDLIB_PATH = "NLS_STDLIB_PATH"
+PROJECT_STDLIB_REL = Path(".nls") / "stdlib"
+
+_DOMAIN_TOKEN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$")
+_USE_SPEC = re.compile(r"^v(?P<major>\d+)\.(?P<domain>.+)$")
+
+
+@dataclass(frozen=True)
+class ResolvedUse:
+    domain: str
+    major: int
+    candidate_relpath: str
+    path: Path
+
+
+class StdlibUseError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        code: str,
+        domain: str,
+        major: int,
+        candidate_relpath: str,
+        attempted_roots: list[Path],
+        message: str,
+    ) -> None:
+        self.code = code
+        self.domain = domain
+        self.major = major
+        self.candidate_relpath = candidate_relpath
+        self.attempted_roots = attempted_roots
+        super().__init__(message)
+
+
+def bundled_stdlib_root() -> Path:
+    return Path(__file__).resolve().parent / "stdlib"
+
+
+def bundled_default_major(*, root: Path) -> int:
+    manifest_path = root / "MANIFEST.json"
+    if not manifest_path.exists():
+        return 1
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        return int(data.get("default_major", 1))
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        return 1
+
+
+def parse_use_spec(spec: str, *, default_major: int) -> tuple[int, str]:
+    raw = (spec or "").strip()
+    m = _USE_SPEC.match(raw)
+    if m:
+        return int(m.group("major")), m.group("domain")
+    return int(default_major), raw
+
+
+def domain_to_relpath(*, major: int, domain: str) -> str:
+    return f"v{major}/" + domain.replace(".", "/") + ".nl"
+
+
+def _missing_domain_error(
+    *,
+    domain_spec: str,
+    domain: str,
+    major: int,
+    roots: list[Path],
+) -> StdlibUseError:
+    candidate_rel = domain_to_relpath(major=major, domain=domain)
+    # NOTE: tests assert for stable code + candidate_relpath + attempted_roots.
+    return StdlibUseError(
+        code="EUSE001",
+        domain=domain or domain_spec,
+        major=major,
+        candidate_relpath=candidate_rel,
+        attempted_roots=roots,
+        message=f"Missing stdlib domain: {domain_spec}",
+    )
+
+
+def stdlib_search_roots(
+    *,
+    cwd: Path,
+    cli_roots: list[Path] | None = None,
+    env_var: str = ENV_STDLIB_PATH,
+    include_project: bool = True,
+    bundled_root: Path | None = None,
+) -> list[Path]:
+    roots: list[Path] = []
+
+    # 1) Project-local override root (highest precedence)
+    if include_project:
+        roots.append(Path(cwd) / PROJECT_STDLIB_REL)
+
+    # 2) CLI roots (repeatable; left-to-right precedence)
+    for r in (cli_roots or []):
+        roots.append(Path(r))
+
+    # 3) Env roots (path list; left-to-right precedence)
+    env_val = os.environ.get(env_var, "")
+    if env_val:
+        for part in env_val.split(os.pathsep):
+            part = part.strip()
+            if part:
+                roots.append(Path(part))
+
+    # 4) Bundled (lowest precedence)
+    roots.append(bundled_root or bundled_stdlib_root())
+
+    # Ignore missing roots (Slice C)
+    return [r for r in roots if r.exists() and r.is_dir()]
+
+
+def resolve_use(
+    *,
+    domain_spec: str,
+    roots: list[Path],
+    default_major: int,
+) -> ResolvedUse:
+    major, domain = parse_use_spec(domain_spec, default_major=default_major)
+
+    if not domain or not _DOMAIN_TOKEN.match(domain):
+        # Treat invalid domains as missing for Slice C.
+        raise _missing_domain_error(domain_spec=domain_spec, domain=domain or "", major=major, roots=roots)
+
+    candidate_rel = domain_to_relpath(major=major, domain=domain)
+    attempted: list[Path] = []
+    for root in roots:
+        attempted.append(root)
+        candidate = root / candidate_rel
+        if candidate.exists() and candidate.is_file():
+            return ResolvedUse(domain=domain, major=major, candidate_relpath=candidate_rel, path=candidate)
+
+    raise _missing_domain_error(domain_spec=domain_spec, domain=domain, major=major, roots=attempted)
+

--- a/tests/test_issue_90_use_directives.py
+++ b/tests/test_issue_90_use_directives.py
@@ -1,0 +1,406 @@
+"""Issue #90 — `@use` directives (Slice C) end-to-end contract tests.
+
+Contract source: docs/design/issue-90-use-directives.md
+
+These tests are intentionally written for TDD Red phase: they define expected
+behavior for stdlib resolution and override precedence. They should FAIL on the
+current implementation until Issue #90 is implemented.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+def _repo_root() -> Path:
+    # tests/ is at repo_root/tests/
+    return Path(__file__).resolve().parents[1]
+
+
+def _pythonpath_env(*, extra_paths: Iterable[Path]) -> dict[str, str]:
+    """Return env overrides ensuring `python -m nlsc` resolves to this repo."""
+    existing = os.environ.get("PYTHONPATH", "")
+    parts: list[str] = [str(p) for p in extra_paths]
+    if existing:
+        parts.append(existing)
+    return {"PYTHONPATH": os.pathsep.join(parts)}
+
+
+def _run_nlsc(
+    argv: list[str],
+    *,
+    cwd: Path,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if env_overrides:
+        env.update(env_overrides)
+
+    return subprocess.run(
+        [sys.executable, "-m", "nlsc", *argv],
+        cwd=str(cwd),
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
+@dataclass
+class _BundledStdlibSandbox:
+    """Creates a minimal bundled stdlib layout under `nlsc/stdlib/` if absent.
+
+    This is a test harness for Slice C end-to-end tests.
+
+    IMPORTANT:
+    - We only *create missing* files.
+    - We only *delete files we created*.
+
+    This avoids interfering with a future committed bundled stdlib.
+    """
+
+    repo_root: Path
+
+    created_paths: list[Path]
+    manifest: dict
+
+    @classmethod
+    def ensure_minimal_math_core(cls) -> "_BundledStdlibSandbox":
+        repo_root = _repo_root()
+        stdlib_root = repo_root / "nlsc" / "stdlib"
+        created: list[Path] = []
+
+        stdlib_root.mkdir(parents=True, exist_ok=True)
+
+        manifest_path = stdlib_root / "MANIFEST.json"
+        if manifest_path.exists():
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        else:
+            manifest = {
+                "schema": 1,
+                "default_major": 1,
+                "versions": {"v1": {"semver": "1.0.0"}},
+            }
+            manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+            created.append(manifest_path)
+
+        default_major = int(manifest.get("default_major", 1))
+        core_path = stdlib_root / f"v{default_major}" / "math" / "core.nl"
+        if not core_path.exists():
+            core_path.parent.mkdir(parents=True, exist_ok=True)
+            core_path.write_text(
+                """@module math.core\n\n# Minimal bundled stdlib placeholder for tests\n""",
+                encoding="utf-8",
+            )
+            created.append(core_path)
+
+        return cls(repo_root=repo_root, created_paths=created, manifest=manifest)
+
+    @property
+    def default_major(self) -> int:
+        return int(self.manifest.get("default_major", 1))
+
+    @property
+    def bundled_stdlib_root(self) -> Path:
+        return self.repo_root / "nlsc" / "stdlib"
+
+    def cleanup(self) -> None:
+        # Remove files we created, then prune empty dirs upward.
+        for p in sorted(self.created_paths, key=lambda x: len(str(x)), reverse=True):
+            try:
+                if p.is_dir():
+                    shutil.rmtree(p)
+                else:
+                    p.unlink(missing_ok=True)
+            except Exception:
+                # Best-effort cleanup; do not mask test failures.
+                pass
+
+        # Prune newly-empty directories we might have created.
+        for p in self.created_paths:
+            for parent in [p.parent, *p.parents]:
+                if parent == (self.repo_root / "nlsc"):
+                    break
+                try:
+                    parent.rmdir()
+                except OSError:
+                    break
+
+
+def test_should_resolve_bundled_stdlib_and_compile_when_use_directive_is_present(tmp_path: Path):
+    """Happy path: `@use math.core` resolves bundled stdlib and compilation succeeds."""
+
+    sandbox = _BundledStdlibSandbox.ensure_minimal_math_core()
+    try:
+        program = """\
+@module main
+@target python
+@use math.core
+
+[noop]
+PURPOSE: No-op
+RETURNS: 1
+"""
+        src = tmp_path / "main.nl"
+        src.write_text(program, encoding="utf-8")
+
+        result = _run_nlsc(
+            ["--parser", "regex", "compile", str(src)],
+            cwd=tmp_path,
+            env_overrides=_pythonpath_env(extra_paths=[sandbox.repo_root]),
+        )
+
+        expected_rel = f"v{sandbox.default_major}/math/core.nl"
+        expected_bundled = sandbox.bundled_stdlib_root / expected_rel
+
+        assert result.returncode == 0, (
+            "Expected compilation to succeed (exit 0) when bundled stdlib contains the domain. "
+            f"Got exit {result.returncode}.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+        assert str(expected_bundled).replace("\\", "/") in (result.stdout + result.stderr).replace("\\", "/"), (
+            "Expected output to include the resolved bundled stdlib path for `@use math.core`. "
+            f"Expected to mention: {expected_bundled}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+    finally:
+        sandbox.cleanup()
+
+
+def test_should_fail_with_EUSE001_when_domain_is_missing(tmp_path: Path):
+    """Error path: missing domain must raise deterministic `EUSE001` with diagnostics."""
+
+    sandbox = _BundledStdlibSandbox.ensure_minimal_math_core()
+    try:
+        # Ensure the specific module is missing even if core.nl exists.
+        missing_rel = f"v{sandbox.default_major}/math/missing.nl"
+        missing_abs = sandbox.bundled_stdlib_root / missing_rel
+        if missing_abs.exists():
+            missing_abs.unlink()
+
+        program = """\
+@module main
+@target python
+@use math.missing
+
+[noop]
+PURPOSE: No-op
+RETURNS: 1
+"""
+        src = tmp_path / "main.nl"
+        src.write_text(program, encoding="utf-8")
+
+        result = _run_nlsc(
+            ["--parser", "regex", "compile", str(src)],
+            cwd=tmp_path,
+            env_overrides=_pythonpath_env(extra_paths=[sandbox.repo_root]),
+        )
+
+        assert result.returncode != 0, (
+            "Expected compilation to fail (non-zero) when `@use` domain is missing. "
+            f"Got exit {result.returncode}.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+
+        combined = (result.stdout + "\n" + result.stderr)
+        assert "EUSE001" in combined, (
+            "Expected missing `@use` domain error to include deterministic code `EUSE001`. "
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+        assert "math.missing" in combined, (
+            "Expected missing domain error to include `domain=math.missing` (or equivalent). "
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+        assert missing_rel.replace("\\", "/") in combined.replace("\\", "/"), (
+            "Expected missing domain error to include `candidate_relpath` of the attempted module. "
+            f"Expected relpath: {missing_rel}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+        assert "attempted_roots" in combined, (
+            "Expected missing domain error to include `attempted_roots` diagnostics. "
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+    finally:
+        sandbox.cleanup()
+
+
+def test_should_prefer_project_local_stdlib_override_over_bundled_when_both_exist(tmp_path: Path):
+    """Precedence: `.nls/stdlib/` overrides bundled stdlib when both contain the domain."""
+
+    sandbox = _BundledStdlibSandbox.ensure_minimal_math_core()
+    try:
+        default_major = sandbox.default_major
+
+        # Project-local override root
+        project_override = tmp_path / ".nls" / "stdlib" / f"v{default_major}" / "math" / "core.nl"
+        project_override.parent.mkdir(parents=True, exist_ok=True)
+        project_override.write_text(
+            """@module math.core\n\n# Project-local override\n""",
+            encoding="utf-8",
+        )
+
+        program = """\
+@module main
+@target python
+@use math.core
+
+[noop]
+PURPOSE: No-op
+RETURNS: 1
+"""
+        src = tmp_path / "main.nl"
+        src.write_text(program, encoding="utf-8")
+
+        result = _run_nlsc(
+            ["--parser", "regex", "compile", str(src)],
+            cwd=tmp_path,
+            env_overrides=_pythonpath_env(extra_paths=[sandbox.repo_root]),
+        )
+
+        assert result.returncode == 0, (
+            "Expected compilation to succeed when project-local stdlib override exists. "
+            f"Got exit {result.returncode}.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+
+        combined = (result.stdout + "\n" + result.stderr).replace("\\", "/")
+        expected_override = str(project_override).replace("\\", "/")
+        expected_bundled = str(sandbox.bundled_stdlib_root / f"v{default_major}/math/core.nl").replace("\\", "/")
+
+        assert expected_override in combined, (
+            "Expected `@use math.core` to resolve to project-local override `.nls/stdlib/.../math/core.nl`. "
+            f"Expected to mention: {expected_override}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+        assert expected_bundled not in combined, (
+            "Expected project-local override to take precedence over bundled stdlib (bundled path should not be selected). "
+            f"Bundled path unexpectedly present: {expected_bundled}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+    finally:
+        sandbox.cleanup()
+
+
+def test_should_prefer_cli_stdlib_path_over_env_and_bundled_when_all_exist(tmp_path: Path):
+    """Precedence: CLI `--stdlib-path` overrides env and bundled roots."""
+
+    sandbox = _BundledStdlibSandbox.ensure_minimal_math_core()
+    try:
+        default_major = sandbox.default_major
+
+        # Env root
+        env_root = tmp_path / "env-stdlib"
+        env_mod = env_root / f"v{default_major}" / "math" / "core.nl"
+        env_mod.parent.mkdir(parents=True, exist_ok=True)
+        env_mod.write_text("@module math.core\n# Env override\n", encoding="utf-8")
+
+        # CLI root
+        cli_root = tmp_path / "cli-stdlib"
+        cli_mod = cli_root / f"v{default_major}" / "math" / "core.nl"
+        cli_mod.parent.mkdir(parents=True, exist_ok=True)
+        cli_mod.write_text("@module math.core\n# CLI override\n", encoding="utf-8")
+
+        program = """\
+@module main
+@target python
+@use math.core
+
+[noop]
+PURPOSE: No-op
+RETURNS: 1
+"""
+        src = tmp_path / "main.nl"
+        src.write_text(program, encoding="utf-8")
+
+        env = _pythonpath_env(extra_paths=[sandbox.repo_root])
+        env["NLS_STDLIB_PATH"] = str(env_root)
+
+        result = _run_nlsc(
+            [
+                "--parser",
+                "regex",
+                "compile",
+                str(src),
+                "--stdlib-path",
+                str(cli_root),
+            ],
+            cwd=tmp_path,
+            env_overrides=env,
+        )
+
+        assert result.returncode == 0, (
+            "Expected compilation to succeed and select CLI stdlib root when provided via `--stdlib-path`. "
+            f"Got exit {result.returncode}.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+
+        combined = (result.stdout + "\n" + result.stderr).replace("\\", "/")
+        assert str(cli_mod).replace("\\", "/") in combined, (
+            "Expected `@use math.core` to resolve to CLI-provided stdlib root (highest precedence in this test). "
+            f"Expected to mention: {cli_mod}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+        assert str(env_mod).replace("\\", "/") not in combined, (
+            "Expected CLI `--stdlib-path` to override env root (env path should not be selected). "
+            f"Env path unexpectedly present: {env_mod}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+    finally:
+        sandbox.cleanup()
+
+
+def test_should_prefer_env_stdlib_path_over_bundled_when_both_exist_and_no_cli(tmp_path: Path):
+    """Precedence: env `NLS_STDLIB_PATH` overrides bundled stdlib when CLI is not provided."""
+
+    sandbox = _BundledStdlibSandbox.ensure_minimal_math_core()
+    try:
+        default_major = sandbox.default_major
+
+        env_root = tmp_path / "env-stdlib"
+        env_mod = env_root / f"v{default_major}" / "math" / "core.nl"
+        env_mod.parent.mkdir(parents=True, exist_ok=True)
+        env_mod.write_text("@module math.core\n# Env override\n", encoding="utf-8")
+
+        program = """\
+@module main
+@target python
+@use math.core
+
+[noop]
+PURPOSE: No-op
+RETURNS: 1
+"""
+        src = tmp_path / "main.nl"
+        src.write_text(program, encoding="utf-8")
+
+        env = _pythonpath_env(extra_paths=[sandbox.repo_root])
+        env["NLS_STDLIB_PATH"] = str(env_root)
+
+        result = _run_nlsc(
+            ["--parser", "regex", "compile", str(src)],
+            cwd=tmp_path,
+            env_overrides=env,
+        )
+
+        assert result.returncode == 0, (
+            "Expected compilation to succeed and select env stdlib root when provided via `NLS_STDLIB_PATH`. "
+            f"Got exit {result.returncode}.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+
+        combined = (result.stdout + "\n" + result.stderr).replace("\\", "/")
+        assert str(env_mod).replace("\\", "/") in combined, (
+            "Expected `@use math.core` to resolve to env-provided stdlib root when `NLS_STDLIB_PATH` is set. "
+            f"Expected to mention: {env_mod}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+
+        bundled_mod = sandbox.bundled_stdlib_root / f"v{default_major}/math/core.nl"
+        assert str(bundled_mod).replace("\\", "/") not in combined, (
+            "Expected env stdlib root to take precedence over bundled stdlib (bundled path should not be selected). "
+            f"Bundled path unexpectedly present: {bundled_mod}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
+        )
+    finally:
+        sandbox.cleanup()


### PR DESCRIPTION
## Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added @use directive for declaring stdlib domain dependencies
  * Introduced --stdlib-path CLI flag to specify custom stdlib root directories
  * Implemented deterministic domain-to-path resolution with layered precedence (project-local, CLI, environment, bundled)

* **Documentation**
  * Updated language specification with @use directive syntax
  * Enhanced CLI and error reference documentation for stdlib handling

* **Tests**
  * Added comprehensive tests for stdlib resolution precedence and directive validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->