### PR TITLE
fix(cli): harden graph JSON artifact writes

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -235,6 +235,8 @@ nlsc graph src/order.nl --anlu process-order --dataflow
 nlsc graph src/order.nl --format dot -o deps.dot
 ```
 
+With `--json`, successful `graph` runs return a stable payload with `ok`, `command`, `diagnostics`, `file`, `format`, `anlu`, `dataflow`, `graph_kind`, `output_file`, and `graph`. Output write failures for `--output` stay structured with `EARTIFACT001`.
+
 ---
 
 ### `nlsc diff`

--- a/docs/error-reference.md
+++ b/docs/error-reference.md
@@ -20,7 +20,7 @@ nlsc explain EPARSE001
 | `EINIT002` | `init` | `nlsc init` could not create the project directory or one of the scaffold directories. |
 | `EINIT003` | `init` | `nlsc init` failed while writing a scaffolded project file. |
 | `EFILE001` | `atomize`, `compile`, `verify`, `run`, `test`, `graph`, `diff`, `watch`, `lock:check`, `lock:update` | The requested input path does not exist. |
-| `EARTIFACT001` | `compile`, `lock:update` | A generated artifact could not be read or written. |
+| `EARTIFACT001` | `compile`, `graph`, `lock:update` | A generated artifact could not be read or written. |
 | `EATOM001` | `atomize` | The input Python file failed syntax parsing during atomization. |
 | `EATOM002` | `atomize` | `nlsc atomize` hit an unexpected extraction or write failure. |
 | `EPARSE001` | `compile`, `verify`, `run`, `test`, `graph`, `diff`, `watch`, `lock:check`, `lock:update` | The source file failed syntax parsing. |
@@ -87,7 +87,7 @@ Raised when the input path passed to `atomize`, `compile`, `verify`, `run`, or `
 
 ### `EARTIFACT001` - Artifact I/O failed
 
-Raised when `nlsc compile --json` cannot write a generated artifact such as `<name>.py`, or when `nlsc lock:update --json` cannot read the existing compiled artifact.
+Raised when `nlsc compile --json` cannot write a generated artifact such as `<name>.py`, when `nlsc graph --json --output` cannot write the rendered graph artifact, or when `nlsc lock:update --json` cannot read the existing compiled artifact.
 
 **Fix:** Check the reported artifact path, filesystem permissions, file locks, and encoding/readability, then rerun the command. For `lock:update`, removing the unreadable compiled artifact lets the command fall back to regenerating code in memory.
 

--- a/nlsc/cli.py
+++ b/nlsc/cli.py
@@ -896,7 +896,18 @@ def cmd_graph(args: argparse.Namespace) -> int:
     # Output
     if args.output:
         output_path = Path(args.output)
-        output_path.write_text(output, encoding="utf-8")
+        try:
+            output_path.write_text(output, encoding="utf-8")
+        except OSError as exc:
+            diagnostic = artifact_io_diagnostic(
+                output_path, exc, action="write", command="graph"
+            )
+            if json_output:
+                return _emit_json("graph", [diagnostic], file=str(source_path))
+            print(f"Error [{diagnostic.code}]: {diagnostic.message}", file=sys.stderr)
+            if diagnostic.hint:
+                print(diagnostic.hint, file=sys.stderr)
+            return 1
         if json_output:
             return _emit_json(
                 "graph",

--- a/nlsc/diagnostics.py
+++ b/nlsc/diagnostics.py
@@ -264,9 +264,7 @@ def atomize_failure_diagnostic(
 def artifact_io_diagnostic(
     path: Path, exc: Exception, *, action: str, command: str
 ) -> Diagnostic:
-    hint = (
-        "Check the output path and filesystem permissions, then rerun `nlsc compile`."
-    )
+    hint = f"Check the output path and filesystem permissions, then rerun `nlsc {command}`."
     if command == "lock:update" and action == "read":
         hint = "Check that the compiled artifact exists and is readable, or remove it so `nlsc lock:update` can regenerate it."
 

--- a/nlsc/error_catalog.py
+++ b/nlsc/error_catalog.py
@@ -162,8 +162,8 @@ ERROR_CATALOG: dict[str, ErrorDefinition] = {
     EARTIFACT001: ErrorDefinition(
         code=EARTIFACT001,
         title="Artifact I/O failed",
-        summary="`nlsc compile` or `nlsc lock:update` could not read or write a generated artifact needed to finish the command.",
-        emitted_by=("compile", "lock:update"),
+        summary="`nlsc compile`, `nlsc graph`, or `nlsc lock:update` could not read or write a generated artifact needed to finish the command.",
+        emitted_by=("compile", "graph", "lock:update"),
         common_causes=(
             "The generated output path is not writable, is locked, or the filesystem rejected the write.",
             "The existing compiled artifact is unreadable, missing expected permissions, or contains undecodable bytes.",

--- a/tests/test_cli_error_json.py
+++ b/tests/test_cli_error_json.py
@@ -1174,6 +1174,49 @@ RETURNS: 1
     assert output_path.read_text(encoding="utf-8") == payload["graph"]
 
 
+def test_graph_json_reports_output_write_failure(
+    capsys: Any, monkeypatch: Any, tmp_path: Path
+) -> None:
+    source_path = tmp_path / "graph_write_fail.nl"
+    output_path = tmp_path / "graph_write_fail.mmd"
+    source_path.write_text(
+        "@module graph-write-fail\n@target python\n\n[main]\nPURPOSE: Ok\nRETURNS: 1\n",
+        encoding="utf-8",
+    )
+    real_write_text = Path.write_text
+
+    def fake_write_text(self: Path, data: str, *args: Any, **kwargs: Any) -> int:
+        if self == output_path:
+            raise OSError("disk full")
+        return real_write_text(self, data, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fake_write_text)
+
+    exit_code = main(
+        ["graph", str(source_path), "--json", "--output", str(output_path)]
+    )
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload == {
+        "ok": False,
+        "command": "graph",
+        "diagnostics": [
+            {
+                "code": "EARTIFACT001",
+                "file": str(output_path),
+                "line": None,
+                "col": None,
+                "message": f"Failed to write artifact: {output_path} (disk full)",
+                "hint": "Check the output path and filesystem permissions, then rerun `nlsc graph`.",
+            }
+        ],
+        "file": str(source_path),
+    }
+    assert captured.err == ""
+
+
 def test_graph_json_reports_rendered_dataflow_kind_for_anlu_ascii(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_cli_explain.py
+++ b/tests/test_cli_explain.py
@@ -97,6 +97,17 @@ def test_explain_command_prints_init_write_failure_details() -> None:
     assert result.stderr == ""
 
 
+def test_explain_command_prints_artifact_io_failure_details() -> None:
+    result = _run_nlsc("explain", "EARTIFACT001")
+
+    assert result.returncode == 0
+    assert "EARTIFACT001" in result.stdout
+    assert "Artifact I/O failed" in result.stdout
+    assert "graph" in result.stdout
+    assert "lock:update" in result.stdout
+    assert result.stderr == ""
+
+
 def test_explain_command_prints_lsp_dependency_error_details() -> None:
     result = _run_nlsc("explain", "ELSP001")
 


### PR DESCRIPTION
## Summary
- route `nlsc graph --json --output` write failures through the existing `EARTIFACT001` diagnostic path instead of surfacing raw `OSError`
- extend the artifact I/O catalog/docs so `graph` is documented as an `EARTIFACT001` emitter
- cover the new JSON failure path and adjacent explain output in tests

## Testing
- python -m pytest tests/test_cli_error_json.py -k \"graph_json\" -v
- python -m pytest tests/test_cli_explain.py -k \"artifact_io_failure_details or known_error_details\" -v
- python -m pytest tests/test_cli_error_json.py -k \"artifact_write_failure or compiled_artifact_read_failure\" -v
- python -m pytest tests/test_cli_error_json.py tests/test_cli_explain.py -v

Refs #148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated CLI and error reference documentation to document `nlsc graph` command behavior and supported error codes.

* **Bug Fixes**
  * Improved error handling in `nlsc graph` command when output file write operations fail.
  * Errors now report in structured JSON format when `--json` flag is used.
  * Error messages now provide command-specific guidance for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->